### PR TITLE
chore: add Makefile and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,18 @@
+# Binary
 swat-dashboard
 swat-dashboard.exe
+*.exe
+
+# OS
+.DS_Store
+
+# Editor swap files
+*.swp
+*.swo
+
+# IDE
+.idea/
+.vscode/
+
+# Temp
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+BINARY := swat-dashboard
+
+ifeq ($(OS),Windows_NT)
+	BINARY := $(BINARY).exe
+endif
+
+.PHONY: build run clean test lint
+
+build:
+	go build -o $(BINARY) .
+
+run: build
+	./$(BINARY)
+
+clean:
+	$(RM) $(BINARY)
+
+test:
+	go test ./...
+
+lint:
+	go vet ./...


### PR DESCRIPTION
## What
Add a Makefile with standard Go project targets and expand .gitignore with common patterns.

## Why
The repository lacked build automation. A Makefile provides a consistent interface for building, testing, and linting. The .gitignore was minimal and missing common patterns for IDE files, OS artifacts, and temp directories.

## Changes
- **Makefile**: Added targets for build (with OS-aware .exe suffix), run, clean, test, and lint. Default target is build.
- **.gitignore**: Added patterns for binary outputs, IDE directories (.idea/, .vscode/), OS files (.DS_Store), editor swap files (*.swp, *.swo), and tmp/.

## How to Test
1. Run `make build`  should produce `swat-dashboard` (or `swat-dashboard.exe` on Windows)
2. Run `make test`  should run Go tests
3. Run `make lint`  should run go vet
4. Run `make clean`  should remove the binary
5. Verify .gitignore excludes the expected patterns