### PR TITLE
feat: add /api/stats endpoint and fix frontend stat counters

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,6 +234,16 @@ func homeDir() string {
 
 // --- HTTP Handlers ---
 
+// handleStats returns operation counts by status.
+func handleStats(w http.ResponseWriter, r *http.Request) {
+	all, _ := operation.List()
+	counts := map[string]int{"active": 0, "queued": 0, "completed": 0, "failed": 0}
+	for _, op := range all {
+		counts[op.Status]++
+	}
+	json.NewEncoder(w).Encode(counts)
+}
+
 func handleOps(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	squad := q.Get("squad")
@@ -373,6 +383,7 @@ func main() {
 	}
 
 	// API routes
+	http.HandleFunc("/api/stats", handleStats)
 	http.HandleFunc("/api/ops", handleOps)
 	http.HandleFunc("/api/squads", handleSquads)
 	http.HandleFunc("/api/file", handleOpFile)

--- a/static/index.html
+++ b/static/index.html
@@ -294,9 +294,16 @@ async function loadOps() {
 
   document.getElementById('load-more').style.display = currentOffset < totalOps ? '' : 'none';
 
-  // Update stats
-  const allOps = data.operations || [];
-  document.getElementById('stat-active').textContent = `Active: ${active.length}`;
+  // Update stats from dedicated endpoint
+  try {
+    const statsResp = await fetch('/api/stats');
+    const stats = await statsResp.json();
+    document.getElementById('stat-active').textContent = `Active: ${(stats.active || 0) + (stats.queued || 0)}`;
+    document.getElementById('stat-completed').textContent = `Completed: ${stats.completed || 0}`;
+    document.getElementById('stat-failed').textContent = `Failed: ${stats.failed || 0}`;
+  } catch(e) {
+    document.getElementById('stat-active').textContent = `Active: ${active.length}`;
+  }
 }
 
 async function loadMore() {


### PR DESCRIPTION
## What
Add a dedicated `GET /api/stats` endpoint and fix the dashboard header to show correct Completed and Failed operation counts.

## Why
The frontend stat counters for Completed and Failed were always showing 0 because `loadOps()` only counted operations from its filtered/paginated result set and only updated the Active counter. A dedicated stats endpoint that scans all operations provides accurate counts.

## Changes
- **main.go**: Added `handleStats` handler that calls `operation.List()`, counts operations by status, and returns JSON. Registered at `/api/stats`.
- **static/index.html**: Updated `loadOps()` to fetch `/api/stats` and set all three header counters (Active+Queued, Completed, Failed).

## How to Test
1. Run the dashboard: `go run .`
2. Verify `curl localhost:8370/api/stats` returns JSON with correct counts
3. Confirm the header shows accurate Active, Completed, and Failed numbers