### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Lint
+        run: go vet ./...
+
+      - name: Build
+        run: go build .
+
+      - name: Test
+        run: go test ./...
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Lint
+        run: go vet ./...
+
+      - name: Build
+        run: go build .
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## What
Add GitHub Actions CI workflow for automated build and test.

## Why
Enable continuous integration to catch build failures and test regressions on every push and PR to main.

## Changes
- .github/workflows/ci.yml: New CI workflow with two jobs:
  - **build-and-test** (ubuntu-latest): checkout, setup Go 1.24, vet, build, test
  - **build-windows** (windows-latest): same steps for cross-platform verification

## How to Test
1. Merge this PR  the workflow will activate on subsequent pushes/PRs to main
2. Or push a commit to this branch to see the workflow run