### PR TITLE
test: add unit tests for HTTP API handlers

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,6 +234,16 @@ func homeDir() string {
 
 // --- HTTP Handlers ---
 
+// handleStats returns operation counts by status.
+func handleStats(w http.ResponseWriter, r *http.Request) {
+	all, _ := operation.List()
+	counts := map[string]int{"active": 0, "queued": 0, "completed": 0, "failed": 0}
+	for _, op := range all {
+		counts[op.Status]++
+	}
+	json.NewEncoder(w).Encode(counts)
+}
+
 func handleOps(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	squad := q.Get("squad")
@@ -373,6 +383,7 @@ func main() {
 	}
 
 	// API routes
+	http.HandleFunc("/api/stats", handleStats)
 	http.HandleFunc("/api/ops", handleOps)
 	http.HandleFunc("/api/squads", handleSquads)
 	http.HandleFunc("/api/file", handleOpFile)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleStats(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	rec := httptest.NewRecorder()
+
+	handleStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var result map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	for _, key := range []string{"active", "queued", "completed", "failed"} {
+		if _, ok := result[key]; !ok {
+			t.Errorf("missing key %q in stats response", key)
+		}
+	}
+}
+
+func TestHandleOps(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/ops", nil)
+		rec := httptest.NewRecorder()
+
+		handleOps(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode JSON: %v", err)
+		}
+
+		if _, ok := result["operations"]; !ok {
+			t.Error("missing 'operations' key")
+		}
+		if _, ok := result["total"]; !ok {
+			t.Error("missing 'total' key")
+		}
+
+		// operations must be an array (or null)
+		switch ops := result["operations"].(type) {
+		case []interface{}:
+			// ok
+			_ = ops
+		case nil:
+			// ok — no operations found
+		default:
+			t.Errorf("expected 'operations' to be array or null, got %T", result["operations"])
+		}
+
+		// total must be a number
+		if _, ok := result["total"].(float64); !ok {
+			t.Errorf("expected 'total' to be a number, got %T", result["total"])
+		}
+	})
+
+	t.Run("with query params", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/ops?limit=5&offset=0&squad=test-squad&status=completed&q=search", nil)
+		rec := httptest.NewRecorder()
+
+		handleOps(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode JSON: %v", err)
+		}
+
+		if _, ok := result["operations"]; !ok {
+			t.Error("missing 'operations' key")
+		}
+		if _, ok := result["total"]; !ok {
+			t.Error("missing 'total' key")
+		}
+	})
+}
+
+func TestHandleSquads(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/squads", nil)
+	rec := httptest.NewRecorder()
+
+	handleSquads(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	// Response must be a valid JSON array
+	var result []interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		// Could be null if no squads — try decoding as null
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodGet, "/api/squads", nil)
+		handleSquads(rec2, req2)
+
+		var raw json.RawMessage
+		if err2 := json.NewDecoder(rec2.Body).Decode(&raw); err2 != nil {
+			t.Fatalf("failed to decode JSON: %v (original: %v)", err2, err)
+		}
+		// null is valid
+		if string(raw) != "null" {
+			t.Fatalf("expected JSON array or null, got: %s", string(raw))
+		}
+	}
+}
+
+func TestHandleRuntimes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/runtimes", nil)
+	rec := httptest.NewRecorder()
+
+	handleRuntimes(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var result []map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	if len(result) == 0 {
+		t.Fatal("expected at least one runtime entry")
+	}
+
+	for i, rt := range result {
+		if _, ok := rt["name"]; !ok {
+			t.Errorf("runtime[%d]: missing 'name' field", i)
+		}
+		if _, ok := rt["available"]; !ok {
+			t.Errorf("runtime[%d]: missing 'available' field", i)
+		}
+	}
+}
+
+func TestHandleOpFile(t *testing.T) {
+	t.Run("missing params returns 400", func(t *testing.T) {
+		// No params at all
+		req := httptest.NewRequest(http.MethodGet, "/api/file", nil)
+		rec := httptest.NewRecorder()
+		handleOpFile(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for missing params, got %d", rec.Code)
+		}
+
+		// Only op param
+		req = httptest.NewRequest(http.MethodGet, "/api/file?op=some-id", nil)
+		rec = httptest.NewRecorder()
+		handleOpFile(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for missing file param, got %d", rec.Code)
+		}
+
+		// Only file param
+		req = httptest.NewRequest(http.MethodGet, "/api/file?file=OPERATION.md", nil)
+		rec = httptest.NewRecorder()
+		handleOpFile(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for missing op param, got %d", rec.Code)
+		}
+	})
+
+	t.Run("nonexistent op returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/file?op=nonexistent-op-id&file=OPERATION.md", nil)
+		rec := httptest.NewRecorder()
+		handleOpFile(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404 for nonexistent op, got %d", rec.Code)
+		}
+	})
+}
+
+func TestContainsCI(t *testing.T) {
+	tests := []struct {
+		s, sub string
+		want   bool
+	}{
+		{"Hello World", "hello", true},
+		{"Hello World", "WORLD", true},
+		{"Hello World", "world", true},
+		{"Hello World", "Hello World", true},
+		{"Hello World", "xyz", false},
+		{"", "", true},
+		{"abc", "", true},
+		{"", "a", false},
+		{"FooBarBaz", "obar", true},
+		{"FooBarBaz", "OBARBAZ", true},
+	}
+
+	for _, tc := range tests {
+		got := containsCI(tc.s, tc.sub)
+		if got != tc.want {
+			t.Errorf("containsCI(%q, %q) = %v, want %v", tc.s, tc.sub, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What
Add comprehensive unit tests for all HTTP API handlers in main_test.go.

## Why
The dashboard API had no test coverage. These tests verify the HTTP layer returns valid JSON with the expected structure, and handles error cases correctly.

## Changes
- **main_test.go** (new): 6 test functions covering all API handlers
  - TestHandleStats: GET /api/stats returns JSON with active/queued/completed/failed keys
  - TestHandleOps: GET /api/ops returns operations array and total; tests with query params (limit, offset, squad, status, q)
  - TestHandleSquads: GET /api/squads returns a JSON array
  - TestHandleRuntimes: GET /api/runtimes returns entries with name and available fields
  - TestHandleOpFile: 400 for missing params, 404 for nonexistent op
  - TestContainsCI: case-insensitive substring matching with various inputs
- **main.go**: Added handleStats handler and /api/stats route (mirrors PR #2 for test compilability)

## How to Test
```
go test -v ./...
```
All 6 tests should pass. Tests work regardless of ~/.swat/ directory state.