### PR TITLE
ci: apply review suggestions from PR #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -16,6 +19,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: true
 
       - name: Lint
         run: go vet ./...
@@ -24,23 +28,4 @@ jobs:
         run: go build .
 
       - name: Test
-        run: go test ./...
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - name: Lint
-        run: go vet ./...
-
-      - name: Build
-        run: go build .
-
-      - name: Test
-        run: go test ./...
+        run: go test -race ./...


### PR DESCRIPTION
## What
Apply the 3 non-blocking review suggestions from PR #4 to the CI workflow.

## Why
PR #4 was merged before these suggestions could be addressed. This follow-up PR implements them.

## Changes
- .github/workflows/ci.yml:
  - Enable Go module caching (cache: true on actions/setup-go@v5)
  - Use matrix strategy (os: [ubuntu-latest, windows-latest]) to consolidate duplicate jobs
  - Enable race detector (go test -race ./...)

## How to Test
1. Check CI workflow runs on this PR
2. Verify both ubuntu and windows matrix jobs pass
3. Confirm module caching is active in Setup Go step logs