### PR TITLE
feat: add release workflow and version support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
+          go build -ldflags "-X main.version=${{ github.ref_name }}" -o "swat-dashboard${EXT}" .
+
+      - name: Package (tar.gz for unix)
+        if: matrix.goos != 'windows'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PLATFORM="${{ matrix.goos }}-${{ matrix.goarch }}"
+          tar -czf "swat-dashboard-${TAG}-${PLATFORM}.tar.gz" swat-dashboard
+
+      - name: Package (zip for windows)
+        if: matrix.goos == 'windows'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PLATFORM="${{ matrix.goos }}-${{ matrix.goarch }}"
+          zip "swat-dashboard-${TAG}-${PLATFORM}.zip" swat-dashboard.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: swat-dashboard-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: swat-dashboard-*.*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            swat-dashboard-*.tar.gz
+            swat-dashboard-*.zip

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/fs"
 	"log"
@@ -22,6 +23,9 @@ import (
 	"github.com/LangSensei/swat/commander/operation"
 	"github.com/gorilla/websocket"
 )
+
+// version is set at build time via ldflags: -X main.version=v1.2.3
+var version = "dev"
 
 //go:embed static/*
 var staticFiles embed.FS
@@ -377,6 +381,14 @@ func openBrowser(url string) {
 }
 
 func main() {
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("swat-dashboard %s\n", version)
+		os.Exit(0)
+	}
+
 	port := "8370"
 	if p := os.Getenv("PORT"); p != "" {
 		port = p
@@ -401,7 +413,7 @@ func main() {
 	}
 
 	url := fmt.Sprintf("http://localhost:%s", port)
-	fmt.Printf("SWAT Dashboard running at %s\n", url)
+	fmt.Printf("SWAT Dashboard %s running at %s\n", version, url)
 
 	// Auto-start available CLI sessions
 	autoStartSessions()


### PR DESCRIPTION
## What
Add a GitHub Actions release workflow and version support to swat-dashboard.

## Why
Enable automated binary releases when version tags are pushed, matching the swat repo's release pattern.

## Changes
- **.github/workflows/release.yml**: New release workflow triggered on `v*` tags. Builds 5 targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64), packages as tar.gz (unix) or zip (windows), and creates a GitHub release using softprops/action-gh-release@v2. Unlike swat, packages only the binary (static files are embedded via go:embed).
- **main.go**: Added `var version = "dev"` package-level variable with ldflags support (`-X main.version`). Added `--version` flag. Updated startup message to include version string.

## How to Test
1. `go build -ldflags "-X main.version=v0.1.0" -o swat-dashboard . && ./swat-dashboard --version` should print `swat-dashboard v0.1.0`
2. `go test ./...`  all 6 tests pass
3. Push a `v*` tag to trigger the release workflow