### PR TITLE
feat: add multi-artifact viewer in operation detail panel

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,12 +124,11 @@ func listSquads() []string {
 }
 
 func readOpFile(opId, filename string) (string, error) {
-	op, err := operation.Find(opId)
+	dir, err := opDir(opId)
 	if err != nil {
 		return "", err
 	}
-	home, _ := os.UserHomeDir()
-	path := filepath.Join(home, ".swat", "squads", op.Squad, "operations", opId, filename)
+	path := filepath.Join(dir, filename)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
@@ -269,6 +268,50 @@ func handleSquads(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(listSquads())
 }
 
+// opDir returns the filesystem path for a given operation ID.
+func opDir(opID string) (string, error) {
+	op, err := operation.Find(opID)
+	if err != nil {
+		return "", err
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".swat", "squads", op.Squad, "operations", opID), nil
+}
+
+// handleOpFiles returns a JSON array of non-hidden file names in the operation directory.
+func handleOpFiles(w http.ResponseWriter, r *http.Request) {
+	opID := r.URL.Query().Get("op")
+	if opID == "" {
+		http.Error(w, "missing op", 400)
+		return
+	}
+	dir, err := opDir(opID)
+	if err != nil {
+		http.Error(w, "not found", 404)
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, "not found", 404)
+		} else {
+			http.Error(w, "internal error", 500)
+		}
+		return
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		files = append(files, e.Name())
+	}
+	if files == nil {
+		files = []string{}
+	}
+	json.NewEncoder(w).Encode(files)
+}
+
 func handleOpFile(w http.ResponseWriter, r *http.Request) {
 	opId := r.URL.Query().Get("op")
 	file := r.URL.Query().Get("file")
@@ -386,6 +429,7 @@ func main() {
 	http.HandleFunc("/api/stats", handleStats)
 	http.HandleFunc("/api/ops", handleOps)
 	http.HandleFunc("/api/squads", handleSquads)
+	http.HandleFunc("/api/files", handleOpFiles)
 	http.HandleFunc("/api/file", handleOpFile)
 	http.HandleFunc("/api/runtimes", handleRuntimes)
 	http.HandleFunc("/ws/session", handleSessionWS)

--- a/main_test.go
+++ b/main_test.go
@@ -188,6 +188,26 @@ func TestHandleOpFile(t *testing.T) {
 	})
 }
 
+func TestHandleOpFiles(t *testing.T) {
+	t.Run("missing op returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/files", nil)
+		rec := httptest.NewRecorder()
+		handleOpFiles(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for missing op param, got %d", rec.Code)
+		}
+	})
+
+	t.Run("nonexistent op returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/files?op=nonexistent-op-id", nil)
+		rec := httptest.NewRecorder()
+		handleOpFiles(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404 for nonexistent op, got %d", rec.Code)
+		}
+	})
+}
+
 func TestContainsCI(t *testing.T) {
 	tests := []struct {
 		s, sub string

--- a/static/index.html
+++ b/static/index.html
@@ -75,6 +75,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 .detail-value { font-size: 14px; line-height: 1.6; }
 .detail-value pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-word; }
 
+/* File tabs */
+.file-tabs { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+.file-tab { padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 12px; color: var(--fg2); background: transparent; border: 1px solid transparent; font-family: monospace; }
+.file-tab:hover { background: var(--bg3); }
+.file-tab.active { background: var(--bg3); color: var(--fg); border-color: var(--border); }
+
 /* Empty state */
 .empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--fg2); font-size: 14px; }
 </style>
@@ -345,39 +351,85 @@ async function selectOp(op) {
   const content = document.getElementById('detail-content');
   content.style.display = '';
 
-  // Load OPERATION.md
-  const resp = await fetch(`/api/file?op=${op.id}&file=OPERATION.md`);
-  const text = resp.ok ? await resp.text() : 'Failed to load';
-
-  content.innerHTML = `
+  // Build metadata section
+  let html = `
     <div class="detail-field">
       <div class="detail-label">Operation</div>
-      <div class="detail-value">${op.id} &nbsp; <span class="status-dot ${op.status}"></span>${op.status}</div>
+      <div class="detail-value">${escapeHtml(op.id)} &nbsp; <span class="status-dot ${op.status}"></span>${escapeHtml(op.status)}</div>
     </div>
     <div class="detail-field">
       <div class="detail-label">Squad</div>
-      <div class="detail-value">${op.squad}</div>
+      <div class="detail-value">${escapeHtml(op.squad)}</div>
     </div>
     <div class="detail-field">
       <div class="detail-label">Brief</div>
-      <div class="detail-value">${op.brief || '—'}</div>
+      <div class="detail-value">${escapeHtml(op.brief || '—')}</div>
     </div>
-    ${op.summary ? `<div class="detail-field"><div class="detail-label">Summary</div><div class="detail-value">${op.summary}</div></div>` : ''}
+    ${op.summary ? `<div class="detail-field"><div class="detail-label">Summary</div><div class="detail-value">${escapeHtml(op.summary)}</div></div>` : ''}
     <div class="detail-field">
       <div class="detail-label">Duration</div>
-      <div class="detail-value">${op.elapsed || '—'} &nbsp; (${op.created_at || '?'} → ${op.completed_at || 'running'})</div>
+      <div class="detail-value">${escapeHtml(op.elapsed || '—')} &nbsp; (${escapeHtml(op.created_at || '?')} → ${escapeHtml(op.completed_at || 'running')})</div>
     </div>
+    <div id="file-tabs-container"></div>
     <div class="detail-field">
-      <div class="detail-label">OPERATION.md</div>
-      <div class="detail-value"><pre>${escapeHtml(text)}</pre></div>
+      <div id="file-content-label" class="detail-label">OPERATION.md</div>
+      <div class="detail-value"><pre id="file-content-pre">Loading...</pre></div>
     </div>
   `;
+  content.innerHTML = html;
+
+  // Fetch file list
+  let files = [];
+  try {
+    const filesResp = await fetch(`/api/files?op=${encodeURIComponent(op.id)}`);
+    if (filesResp.ok) files = await filesResp.json();
+  } catch(e) {}
+
+  // Render file tabs
+  const tabsContainer = document.getElementById('file-tabs-container');
+  if (files.length > 0) {
+    const tabsDiv = document.createElement('div');
+    tabsDiv.className = 'file-tabs';
+    files.forEach(f => {
+      const tab = document.createElement('span');
+      tab.className = 'file-tab';
+      tab.textContent = f;
+      tab.onclick = () => loadFileContent(op.id, f, tabsDiv);
+      tabsDiv.appendChild(tab);
+    });
+    tabsContainer.appendChild(tabsDiv);
+  }
+
+  // Default to OPERATION.md if present, otherwise first file
+  const defaultFile = files.includes('OPERATION.md') ? 'OPERATION.md' : (files[0] || 'OPERATION.md');
+  loadFileContent(op.id, defaultFile, tabsContainer.querySelector('.file-tabs'));
 
   // Highlight selected card
   document.querySelectorAll('.op-card').forEach(c => c.classList.remove('selected'));
   document.querySelectorAll('.op-card').forEach(c => {
     if (c.querySelector('.op-id')?.textContent === op.id) c.classList.add('selected');
   });
+}
+
+async function loadFileContent(opId, filename, tabsDiv) {
+  if (selectedOp !== opId) return;
+  // Update active tab
+  if (tabsDiv) {
+    tabsDiv.querySelectorAll('.file-tab').forEach(t => {
+      t.classList.toggle('active', t.textContent === filename);
+    });
+  }
+  document.getElementById('file-content-label').textContent = filename;
+  const pre = document.getElementById('file-content-pre');
+  pre.textContent = 'Loading...';
+  try {
+    const resp = await fetch(`/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`);
+    if (selectedOp !== opId) return;
+    pre.textContent = resp.ok ? await resp.text() : 'Failed to load';
+  } catch(e) {
+    if (selectedOp !== opId) return;
+    pre.textContent = 'Failed to load';
+  }
 }
 
 function escapeHtml(str) {


### PR DESCRIPTION
## What
Add a multi-artifact viewer to the operation detail panel, allowing users to browse all files in an operation directory instead of only OPERATION.md.

## Why
The detail panel previously only showed OPERATION.md. Operations contain multiple artifacts (plan.md, findings.md, progress.md, report.html, etc.) that are useful for understanding operation outcomes.

## Changes
- **main.go**: Add `opDir()` shared helper, `handleOpFiles` handler for `GET /api/files?op=<id>`, register route. Refactor `readOpFile` to use shared helper. Filters dotfiles and directories, returns proper HTTP error codes (400/404/500).
- **static/index.html**: Add file tab CSS styling. Rewrite `selectOp()` to fetch file list and render clickable tabs. Add `loadFileContent()` with race condition guard. Default to OPERATION.md with fallback to first available file. Uses `textContent` for safe filename rendering.
- **main_test.go**: Add `TestHandleOpFiles` with subtests for missing param (400) and nonexistent op (404).

## How to Test
1. `go build && go test ./...`
2. Run the dashboard and click on an operation - file tabs should appear above the content area
3. Click different file tabs to switch between artifacts
4. Verify hidden files (e.g. .context_refresh_ts) are not shown in tabs