### PR TITLE
feat: add install/uninstall scripts for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,38 @@
 - Filtering by squad, status, and keyword
 - Operation detail viewer
 
+## Installation
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/install.ps1 | iex
+```
+
+After installation, run `swat-dashboard` to open the dashboard in your browser at [http://localhost:8370](http://localhost:8370).
+
+### Uninstall
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/uninstall.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/uninstall.ps1 | iex
+```
+
+Use `--purge` to also remove the `~/.swat/bin/` directory if empty. Use `--yes` to skip the confirmation prompt.
+
 ## Prerequisites
-- Go 1.24+
+- Go 1.24+ (for building from source)
 
 ## Build & Run
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,120 @@
+# SWAT Dashboard Installer for Windows
+# Usage: irm https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "LangSensei/swat-dashboard"
+$BinDir = Join-Path $env:USERPROFILE ".swat\bin"
+
+# --- Helpers ---
+
+function Info  { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Cyan }
+function Ok    { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Green }
+function Err   { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Red }
+function Warn  { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Yellow }
+
+# --- Safety ---
+if ($env:USERNAME -eq "SYSTEM") {
+    Err "Do not run this installer as SYSTEM."
+    exit 1
+}
+
+# --- Detect Platform ---
+
+function Detect-Platform {
+    if (-not [Environment]::Is64BitOperatingSystem) {
+        Err "Only 64-bit Windows (amd64) is supported."
+        exit 1
+    }
+    $script:Platform = "windows-amd64"
+    Info "Detected platform: $script:Platform"
+}
+
+# --- Download & Extract ---
+
+function Fetch-Release {
+    $apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $apiUrl -UseBasicParsing
+    $tag = $release.tag_name
+
+    if (-not $tag) {
+        Err "Failed to fetch latest release"
+        exit 1
+    }
+
+    $script:Tag = $tag
+    Info "Latest release: $tag"
+
+    # Check if already installed at this version
+    try {
+        $current = & (Join-Path $BinDir "swat-dashboard.exe") --version 2>$null
+        if ($current -match $tag) {
+            Ok "Already up to date ($tag)"
+            exit 0
+        }
+    } catch {}
+
+    $zipName = "swat-dashboard-${tag}-${script:Platform}.zip"
+    $dlUrl = "https://github.com/$Repo/releases/download/${tag}/${zipName}"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "swat-dashboard-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    Info "Downloading $zipName..."
+    Invoke-WebRequest -Uri $dlUrl -OutFile (Join-Path $tmpDir $zipName) -UseBasicParsing
+
+    Info "Extracting..."
+    Expand-Archive -Path (Join-Path $tmpDir $zipName) -DestinationPath $tmpDir -Force
+
+    $script:ExtractDir = $tmpDir
+}
+
+# --- Install ---
+
+function Install-Binary {
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    Copy-Item (Join-Path $script:ExtractDir "swat-dashboard.exe") (Join-Path $BinDir "swat-dashboard.exe") -Force
+    Ok "Binary installed to $BinDir\swat-dashboard.exe"
+}
+
+# --- Post-Install ---
+
+function Post-Install {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$BinDir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$BinDir;$userPath", "User")
+        $env:Path = "$BinDir;$env:Path"
+        Ok "Added $BinDir to user PATH"
+    }
+}
+
+# --- Cleanup ---
+
+function Cleanup {
+    if ($script:ExtractDir -and (Test-Path $script:ExtractDir)) {
+        Remove-Item -Recurse -Force $script:ExtractDir -ErrorAction SilentlyContinue
+    }
+}
+
+# --- Main ---
+
+Write-Host ""
+Info "Installing SWAT Dashboard..."
+Write-Host ""
+
+Detect-Platform
+Fetch-Release
+Install-Binary
+Post-Install
+Cleanup
+
+Write-Host ""
+Ok "SWAT Dashboard installed successfully! 🚀"
+Write-Host ""
+Info "To start the dashboard:"
+Write-Host "  swat-dashboard"
+Write-Host ""
+Write-Host "  This opens your browser at http://localhost:8370"
+Write-Host ""
+Write-Host "  To customize the port:"
+Write-Host '  $env:PORT = "9090"; swat-dashboard'
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SWAT Dashboard Installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/install.sh | bash
+
+REPO="LangSensei/swat-dashboard"
+BIN_DIR="$HOME/.swat/bin"
+
+# --- Safety: refuse to run as root ---
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo -e "\033[0;31m[swat-dashboard]\033[0m Do not run this installer as root or with sudo."
+    echo -e "\033[0;31m[swat-dashboard]\033[0m Run as your normal user:  curl -fsSL ... | bash"
+    exit 1
+fi
+
+info()  { echo -e "\033[0;36m[swat-dashboard]\033[0m $*"; }
+ok()    { echo -e "\033[0;32m[swat-dashboard]\033[0m $*"; }
+err()   { echo -e "\033[0;31m[swat-dashboard]\033[0m $*" >&2; }
+die()   { err "$@"; exit 1; }
+
+# --- Detect Platform ---
+
+detect_platform() {
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+
+    case "$os" in
+        linux)  OS="linux" ;;
+        darwin) OS="darwin" ;;
+        *)      die "Unsupported OS: $os" ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)  ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        *)             die "Unsupported architecture: $arch" ;;
+    esac
+
+    PLATFORM="${OS}-${ARCH}"
+    info "Detected platform: $PLATFORM"
+}
+
+# --- Prerequisites ---
+
+check_prereqs() {
+    local missing=()
+    command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 || missing+=("curl or wget")
+    command -v tar  >/dev/null 2>&1 || missing+=("tar")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        die "Missing prerequisites: ${missing[*]}"
+    fi
+}
+
+# --- Download & Extract ---
+
+download() {
+    local url="$1" dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url"
+    else
+        wget -qO "$dest" "$url"
+    fi
+}
+
+fetch_release() {
+    local api_url="https://api.github.com/repos/$REPO/releases/latest"
+    local tag
+
+    if command -v curl >/dev/null 2>&1; then
+        tag=$(curl -fsSL "$api_url" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+    else
+        tag=$(wget -qO- "$api_url" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+    fi
+
+    if [[ -z "$tag" ]]; then
+        die "Failed to fetch latest release"
+    fi
+
+    TAG="$tag"
+    info "Latest release: $tag"
+
+    # Check if already installed at this version
+    local current
+    current=$("$BIN_DIR/swat-dashboard" --version 2>/dev/null | awk '{print $2}' || true)
+    if [[ -n "$current" ]] && [[ "$current" == "$tag" ]]; then
+        ok "Already up to date ($tag)"
+        exit 0
+    fi
+
+    local tarball="swat-dashboard-${tag}-${PLATFORM}.tar.gz"
+    local dl_url="https://github.com/$REPO/releases/download/${tag}/${tarball}"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    info "Downloading $tarball..."
+    download "$dl_url" "$tmp_dir/$tarball"
+
+    info "Extracting..."
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+
+    EXTRACT_DIR="$tmp_dir"
+}
+
+# --- Install ---
+
+install_binary() {
+    mkdir -p "$BIN_DIR"
+    cp "$EXTRACT_DIR/swat-dashboard" "$BIN_DIR/swat-dashboard"
+    chmod +x "$BIN_DIR/swat-dashboard"
+    ok "Binary installed to $BIN_DIR/swat-dashboard"
+}
+
+# --- Post-Install ---
+
+post_install() {
+    # Symlink to ~/.local/bin (commonly in PATH on Linux/macOS)
+    local local_bin="$HOME/.local/bin"
+    mkdir -p "$local_bin"
+    ln -sf "$BIN_DIR/swat-dashboard" "$local_bin/swat-dashboard"
+    ok "Symlinked $local_bin/swat-dashboard → $BIN_DIR/swat-dashboard"
+
+    # Also add BIN_DIR to shell profiles as fallback
+    if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+        local line="export PATH=\"$BIN_DIR:\$PATH\""
+        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+            if [[ -f "$rc" ]] && ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+                echo "" >> "$rc"
+                echo "# Added by SWAT Dashboard installer" >> "$rc"
+                echo "$line" >> "$rc"
+                ok "Added $BIN_DIR to PATH in $(basename "$rc")"
+            fi
+        done
+        export PATH="$BIN_DIR:$PATH"
+    fi
+}
+
+# --- Cleanup ---
+
+cleanup() {
+    rm -rf "$EXTRACT_DIR"
+}
+
+# --- Main ---
+
+main() {
+    echo ""
+    info "Installing SWAT Dashboard..."
+    echo ""
+
+    detect_platform
+    check_prereqs
+    fetch_release
+    install_binary
+    post_install
+    cleanup
+
+    echo ""
+    ok "SWAT Dashboard installed successfully! 🚀"
+
+    echo ""
+    info "To start the dashboard:"
+    echo "  swat-dashboard"
+    echo ""
+    echo "  This opens your browser at http://localhost:8370"
+    echo ""
+    echo "  To customize the port:"
+    echo "  PORT=9090 swat-dashboard"
+    echo ""
+}
+
+main "$@"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,65 @@
+# SWAT Dashboard Uninstaller for Windows
+# Usage: irm https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/uninstall.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$BinDir = Join-Path $env:USERPROFILE ".swat\bin"
+
+function Info  { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Cyan }
+function Ok    { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Green }
+function Warn  { param($Msg) Write-Host "[swat-dashboard] $Msg" -ForegroundColor Yellow }
+
+$Purge = $args -contains "--purge"
+$Yes = $args -contains "--yes"
+
+Write-Host ""
+Write-Host "  SWAT Dashboard Uninstaller"
+Write-Host "  ==========================="
+Write-Host ""
+
+if (-not $Yes) {
+    Warn "This will remove:"
+    Write-Host "  - Binary: $BinDir\swat-dashboard.exe"
+    Write-Host ""
+    if ($Purge) {
+        Warn "--purge: will also remove $BinDir\ if empty"
+    }
+    Write-Host ""
+    $confirm = Read-Host "Continue? [y/N]"
+    if ($confirm -notin @("y", "Y")) {
+        Info "Aborted."
+        exit 0
+    }
+}
+
+# --- Remove binary ---
+
+$binPath = Join-Path $BinDir "swat-dashboard.exe"
+if (Test-Path $binPath) {
+    Remove-Item -Force $binPath
+    Ok "Removed $binPath"
+} else {
+    Info "Binary not found at $binPath (skipped)"
+}
+
+# --- Purge ---
+
+if ($Purge) {
+    if ((Test-Path $BinDir) -and ((Get-ChildItem $BinDir -Force).Count -eq 0)) {
+        Remove-Item -Force $BinDir
+        Ok "Removed empty $BinDir\"
+    }
+}
+
+# --- Remove from user PATH ---
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -like "*$BinDir*") {
+    $newPath = ($userPath -split ';' | Where-Object { $_ -ne $BinDir }) -join ';'
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Ok "Removed $BinDir from user PATH"
+}
+
+Write-Host ""
+Ok "SWAT Dashboard uninstalled."
+echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SWAT Dashboard Uninstaller
+# Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-dashboard/main/uninstall.sh | bash
+
+BIN_DIR="$HOME/.swat/bin"
+
+info()  { echo -e "\033[0;36m[swat-dashboard]\033[0m $*"; }
+ok()    { echo -e "\033[0;32m[swat-dashboard]\033[0m $*"; }
+warn()  { echo -e "\033[0;33m[swat-dashboard]\033[0m $*"; }
+err()   { echo -e "\033[0;31m[swat-dashboard]\033[0m $*" >&2; }
+
+echo ""
+echo "  SWAT Dashboard Uninstaller"
+echo "  ==========================="
+echo ""
+
+# --- Parse flags ---
+
+PURGE=false
+YES=false
+for arg in "$@"; do
+    case "$arg" in
+        --purge) PURGE=true ;;
+        --yes)   YES=true ;;
+    esac
+done
+
+# --- Confirm ---
+
+if ! $YES; then
+    warn "This will remove:"
+    echo "  - Binary:   $BIN_DIR/swat-dashboard"
+    echo "  - Symlink:  $HOME/.local/bin/swat-dashboard"
+    echo ""
+    if $PURGE; then
+        warn "--purge: will also remove $BIN_DIR/ if empty"
+    fi
+    echo ""
+    read -r -p "Continue? [y/N] " confirm
+    if [[ "$confirm" != [yY] ]]; then
+        info "Aborted."
+        exit 0
+    fi
+fi
+
+# --- Remove binary ---
+
+if [[ -f "$BIN_DIR/swat-dashboard" ]]; then
+    rm -f "$BIN_DIR/swat-dashboard"
+    ok "Removed $BIN_DIR/swat-dashboard"
+else
+    info "Binary not found at $BIN_DIR/swat-dashboard (skipped)"
+fi
+
+# --- Remove symlink ---
+
+local_bin="$HOME/.local/bin/swat-dashboard"
+if [[ -L "$local_bin" ]]; then
+    rm -f "$local_bin"
+    ok "Removed $local_bin"
+fi
+
+# --- Purge ---
+
+if $PURGE; then
+    # Remove BIN_DIR if empty
+    if [[ -d "$BIN_DIR" ]] && [[ -z "$(ls -A "$BIN_DIR" 2>/dev/null)" ]]; then
+        rmdir "$BIN_DIR"
+        ok "Removed empty $BIN_DIR/"
+    fi
+fi
+
+# --- Remove PATH entry from shell profiles ---
+
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    if [[ -f "$rc" ]] && grep -q "# Added by SWAT Dashboard installer" "$rc" 2>/dev/null; then
+        if sed --version &>/dev/null 2>&1; then
+            sed -i '/# Added by SWAT Dashboard installer/{N;d;}' "$rc"
+        else
+            sed -i '' '/# Added by SWAT Dashboard installer/{N;d;}' "$rc"
+        fi
+        ok "Cleaned PATH from $(basename "$rc")"
+    fi
+done
+
+echo ""
+ok "SWAT Dashboard uninstalled."
+echo ""


### PR DESCRIPTION
## What
Add install and uninstall scripts (install.sh, install.ps1, uninstall.sh, uninstall.ps1) for swat-dashboard, plus an Installation section in README.md.

## Why
Users need a simple one-liner to install the dashboard binary without building from source. Modeled after the swat repo's install scripts but simplified for the dashboard (single binary, no blueprints, no node/npm prerequisites).

## Changes
- **install.sh**: Linux/macOS installer  detects platform (linux/darwin x amd64/arm64), fetches latest GitHub release, downloads tar.gz, extracts binary to ~/.swat/bin/swat-dashboard, symlinks to ~/.local/bin, adds to PATH in .bashrc/.zshrc, skips if already at latest version
- **install.ps1**: Windows installer  detects 64-bit Windows, fetches latest release, downloads zip, extracts binary to ~/.swat/bin/swat-dashboard.exe, adds to user PATH
- **uninstall.sh**: Removes binary and symlink, cleans PATH from shell profiles; supports --purge (remove dir if empty) and --yes (skip confirmation)
- **uninstall.ps1**: Removes binary, cleans PATH; supports --purge and --yes flags
- **README.md**: Added Installation section with one-liner install/uninstall commands

## How to Test
1. Create a release on swat-dashboard with the expected archive naming convention
2. Run `curl -fsSL .../install.sh | bash` on Linux/macOS
3. Verify binary installed to ~/.swat/bin/swat-dashboard
4. Run uninstall.sh and verify cleanup
5. Test install.ps1/uninstall.ps1 on Windows