### PR TITLE
fix: address review suggestions on install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Fetch-Release {
     # Check if already installed at this version
     try {
         $current = & (Join-Path $BinDir "swat-dashboard.exe") --version 2>$null
-        if ($current -match $tag) {
+        if ($current -like "*$tag*") {
             Ok "Already up to date ($tag)"
             exit 0
         }

--- a/install.sh
+++ b/install.sh
@@ -150,12 +150,13 @@ main() {
     info "Installing SWAT Dashboard..."
     echo ""
 
+    trap cleanup EXIT
+
     detect_platform
     check_prereqs
     fetch_release
     install_binary
     post_install
-    cleanup
 
     echo ""
     ok "SWAT Dashboard installed successfully! 🚀"

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ post_install() {
 # --- Cleanup ---
 
 cleanup() {
-    rm -rf "$EXTRACT_DIR"
+    rm -rf "${EXTRACT_DIR:-}"
 }
 
 # --- Main ---


### PR DESCRIPTION
## What
Follow-up to PR #10 - addresses the 2 non-blocking review suggestions.

## Why
PR #10 was merged before the review suggestions could be applied.

## Changes
- install.sh: Added trap cleanup EXIT in main() to ensure temp dir cleanup on failure
- install.ps1: Changed -match to -like for version check to avoid regex dot interpretation

## How to Test
1. Review the diff - changes are minimal
2. install.sh: Verify trap cleanup EXIT before functions creating temp dirs
3. install.ps1: Verify -like used instead of -match