### PR TITLE
feat: render operation files by type (markdown, HTML, plain text)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -227,7 +227,7 @@ async function selectOp(op) {
     <div id="file-tabs-container"></div>
     <div class="detail-field">
       <div id="file-content-label" class="detail-label">OPERATION.md</div>
-      <div class="detail-value"><pre id="file-content-pre">Loading...</pre></div>
+      <div class="detail-value"><div id="file-content-area"><pre>Loading...</pre></div></div>
     </div>
   `;
   content.innerHTML = html;
@@ -274,15 +274,30 @@ async function loadFileContent(opId, filename, tabsDiv) {
     });
   }
   document.getElementById('file-content-label').textContent = filename;
-  const pre = document.getElementById('file-content-pre');
-  pre.textContent = 'Loading...';
+
+  const contentArea = document.getElementById('file-content-area');
+  contentArea.innerHTML = '<pre>Loading...</pre>';
+
   try {
     const resp = await fetch(`/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`);
     if (selectedOp !== opId) return;
-    pre.textContent = resp.ok ? await resp.text() : 'Failed to load';
+    const text = resp.ok ? await resp.text() : 'Failed to load';
+
+    const ext = filename.split('.').pop().toLowerCase();
+
+    if (ext === 'md' && typeof marked !== 'undefined') {
+      contentArea.innerHTML = `<div class="md-content">${marked.parse(text)}</div>`;
+    } else if (ext === 'html' || ext === 'htm') {
+      const fileUrl = `/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`;
+      contentArea.innerHTML =
+        `<a href="${escapeHtml(fileUrl)}" target="_blank" class="open-tab-btn">Open in new tab &#8599;</a>` +
+        `<iframe srcdoc="${escapeHtml(text)}" sandbox="allow-same-origin" class="html-frame"></iframe>`;
+    } else {
+      contentArea.innerHTML = `<pre>${escapeHtml(text)}</pre>`;
+    }
   } catch(e) {
     if (selectedOp !== opId) return;
-    pre.textContent = 'Failed to load';
+    contentArea.innerHTML = '<pre>Failed to load</pre>';
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -286,7 +286,9 @@ async function loadFileContent(opId, filename, tabsDiv) {
     const ext = filename.split('.').pop().toLowerCase();
 
     if (ext === 'md' && typeof marked !== 'undefined') {
-      contentArea.innerHTML = `<div class="md-content">${marked.parse(text)}</div>`;
+      const rawHtml = marked.parse(text);
+      const sanitized = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(rawHtml) : rawHtml;
+      contentArea.innerHTML = `<div class="md-content">${sanitized}</div>`;
     } else if (ext === 'html' || ext === 'htm') {
       const fileUrl = `/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`;
       contentArea.innerHTML =
@@ -302,7 +304,7 @@ async function loadFileContent(opId, filename, tabsDiv) {
 }
 
 function escapeHtml(str) {
-  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
 // --- Filters ---

--- a/static/index.html
+++ b/static/index.html
@@ -65,6 +65,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -65,7 +65,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.1/dist/purify.min.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -73,5 +73,19 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 .file-tab:hover { background: var(--bg3); }
 .file-tab.active { background: var(--bg3); color: var(--fg); border-color: var(--border); }
 
+/* Rendered markdown */
+.md-content { line-height: 1.7; }
+.md-content h1, .md-content h2, .md-content h3 { margin: 16px 0 8px; color: var(--fg); }
+.md-content code { background: var(--bg3); padding: 2px 6px; border-radius: 4px; font-size: 13px; }
+.md-content pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; }
+.md-content pre code { background: none; padding: 0; }
+.md-content a { color: var(--accent); }
+.md-content ul, .md-content ol { padding-left: 24px; }
+.md-content blockquote { border-left: 3px solid var(--border); padding-left: 12px; color: var(--fg2); }
+
+/* HTML iframe */
+.html-frame { width: 100%; min-height: 500px; border: 1px solid var(--border); border-radius: 8px; background: #fff; }
+.open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--bg3); border: 1px solid var(--border); color: var(--accent); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
+
 /* Empty state */
 .empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--fg2); font-size: 14px; }


### PR DESCRIPTION
Enhance the detail panel to render operation files differently based on their extension.

## What
Render .md, .html, and other file types appropriately in the operation detail view instead of plain text for all.

## Why
Markdown and HTML reports are much more useful when rendered properly.

## Changes
- **static/index.html**: Added marked.js CDN script tag before app.js
- **static/style.css**: Added markdown content and iframe styles
- **static/app.js**: Updated selectOp() to use div wrapper; updated loadFileContent() to render .md via marked.js, .html/.htm in sandboxed iframe with Open in new tab button, others as plain text

## How to Test
1. `make build && make test`  all Go tests pass
2. Open dashboard, select operation with .md, .html, and .log files
3. Verify .md renders with styled headings/code/links
4. Verify .html displays in iframe with Open in new tab button
5. Verify .log/.yaml/.json show as plain text