### PR TITLE
fix: handle empty files in selectOp() detail panel

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -236,7 +236,7 @@ async function selectOp(op) {
   let files = [];
   try {
     const filesResp = await fetch(`/api/files?op=${encodeURIComponent(op.id)}`);
-    if (filesResp.ok) files = await filesResp.json();
+    if (filesResp.ok) files = (await filesResp.json()) || [];
   } catch(e) {}
 
   // Render file tabs
@@ -255,8 +255,13 @@ async function selectOp(op) {
   }
 
   // Default to OPERATION.md if present, otherwise first file
-  const defaultFile = files.includes('OPERATION.md') ? 'OPERATION.md' : (files[0] || 'OPERATION.md');
-  loadFileContent(op.id, defaultFile, tabsContainer.querySelector('.file-tabs'));
+  if (files.length > 0) {
+    const defaultFile = files.includes('OPERATION.md') ? 'OPERATION.md' : files[0];
+    loadFileContent(op.id, defaultFile, tabsContainer.querySelector('.file-tabs'));
+  } else {
+    document.getElementById('file-content-label').textContent = '';
+    document.getElementById('file-content-pre').textContent = 'No files available';
+  }
 
   // Highlight selected card
   document.querySelectorAll('.op-card').forEach(c => c.classList.remove('selected'));


### PR DESCRIPTION
## What
Fix the detail panel to gracefully handle operations with no files instead of showing 'Failed to load'.

## Why
When clicking an operation that has no OPERATION.md (or no files at all), the UI showed 'OPERATION.md / Failed to load' because `selectOp()` unconditionally tried to load a file - falling back to `'OPERATION.md'` even when no files exist. Additionally, the Go backend returns `null` (not `[]`) for empty file lists, which would crash on `.length`.

## Changes
- `static/app.js`:
  - Normalize null API response to empty array: `(await resp.json()) || []`
  - Guard `loadFileContent()` call behind `files.length > 0` check
  - Show 'No files available' message when files array is empty
  - Remove the `|| 'OPERATION.md'` fallback that forced loading a non-existent file

## How to Test
1. Create an operation directory with no files (or just a directory with no OPERATION.md)
2. Open the dashboard and click that operation
3. The detail panel should show 'No files available' instead of 'Failed to load'