### PR TITLE
fix: fetch active ops separately to avoid pagination cutoff

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -91,6 +91,72 @@ func TestHandleOps(t *testing.T) {
 			t.Error("missing 'total' key")
 		}
 	})
+
+	t.Run("status=active filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/ops?status=active&limit=50", nil)
+		rec := httptest.NewRecorder()
+
+		handleOps(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode JSON: %v", err)
+		}
+
+		if _, ok := result["operations"]; !ok {
+			t.Error("missing 'operations' key")
+		}
+		if _, ok := result["total"]; !ok {
+			t.Error("missing 'total' key")
+		}
+
+		// All returned ops must be active
+		if ops, ok := result["operations"].([]interface{}); ok {
+			for i, rawOp := range ops {
+				op := rawOp.(map[string]interface{})
+				if op["status"] != "active" {
+					t.Errorf("ops[%d]: expected status 'active', got %q", i, op["status"])
+				}
+			}
+		}
+	})
+
+	t.Run("status=queued filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/ops?status=queued&limit=50", nil)
+		rec := httptest.NewRecorder()
+
+		handleOps(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode JSON: %v", err)
+		}
+
+		if _, ok := result["operations"]; !ok {
+			t.Error("missing 'operations' key")
+		}
+		if _, ok := result["total"]; !ok {
+			t.Error("missing 'total' key")
+		}
+
+		// All returned ops must be queued
+		if ops, ok := result["operations"].([]interface{}); ok {
+			for i, rawOp := range ops {
+				op := rawOp.(map[string]interface{})
+				if op["status"] != "queued" {
+					t.Errorf("ops[%d]: expected status 'queued', got %q", i, op["status"])
+				}
+			}
+		}
+	})
 }
 
 func TestHandleSquads(t *testing.T) {

--- a/static/app.js
+++ b/static/app.js
@@ -126,43 +126,82 @@ async function loadOps() {
   const status = document.getElementById('filter-status').value;
   const keyword = document.getElementById('filter-keyword').value;
 
-  const params = new URLSearchParams({ limit: '20', offset: '0' });
-  if (squad) params.set('squad', squad);
-  if (status) params.set('status', status);
-  if (keyword) params.set('q', keyword);
-
-  const resp = await fetch(`/api/ops?${params}`);
-  const data = await resp.json();
-
-  totalOps = data.total;
-  currentOffset = 20;
-
-  // Split active vs history
   const activeList = document.getElementById('active-list');
   const historyList = document.getElementById('history-list');
   activeList.innerHTML = '';
   historyList.innerHTML = '';
 
-  const active = (data.operations || []).filter(op => op.status === 'active' || op.status === 'queued');
-  const rest = (data.operations || []).filter(op => op.status !== 'active' && op.status !== 'queued');
-
-  if (active.length === 0) {
-    activeList.innerHTML = '<div style="padding:8px 12px;color:var(--fg2);font-size:13px;">No active operations</div>';
-  }
-  active.forEach(op => renderOpCard(op, activeList));
-  rest.forEach(op => renderOpCard(op, historyList));
-
-  document.getElementById('load-more').style.display = currentOffset < totalOps ? '' : 'none';
-
-  // Update stats from dedicated endpoint
   try {
-    const statsResp = await fetch('/api/stats');
-    const stats = await statsResp.json();
-    document.getElementById('stat-active').textContent = `Active: ${(stats.active || 0) + (stats.queued || 0)}`;
-    document.getElementById('stat-completed').textContent = `Completed: ${stats.completed || 0}`;
-    document.getElementById('stat-failed').textContent = `Failed: ${stats.failed || 0}`;
+    // When no status filter is set, fetch active+queued ops separately
+    // so they always appear regardless of pagination
+    let activeOps = [];
+    if (!status) {
+      const activeParams = new URLSearchParams({ limit: '50', offset: '0', status: 'active' });
+      if (squad) activeParams.set('squad', squad);
+      if (keyword) activeParams.set('q', keyword);
+
+      const queuedParams = new URLSearchParams({ limit: '50', offset: '0', status: 'queued' });
+      if (squad) queuedParams.set('squad', squad);
+      if (keyword) queuedParams.set('q', keyword);
+
+      const [activeResp, queuedResp] = await Promise.all([
+        fetch(`/api/ops?${activeParams}`),
+        fetch(`/api/ops?${queuedParams}`)
+      ]);
+      const activeData = await activeResp.json();
+      const queuedData = await queuedResp.json();
+      activeOps = [...(activeData.operations || []), ...(queuedData.operations || [])];
+    }
+
+    // Main paginated fetch for the history list (or filtered view)
+    const params = new URLSearchParams({ limit: '20', offset: '0' });
+    if (squad) params.set('squad', squad);
+    if (status) params.set('status', status);
+    if (keyword) params.set('q', keyword);
+
+    const resp = await fetch(`/api/ops?${params}`);
+    const data = await resp.json();
+
+    totalOps = data.total;
+    currentOffset = 20;
+
+    if (!status) {
+      // No status filter: active section from dedicated fetch, history from paginated fetch minus active/queued
+      if (activeOps.length === 0) {
+        activeList.innerHTML = '<div style="padding:8px 12px;color:var(--fg2);font-size:13px;">No active operations</div>';
+      }
+      activeOps.forEach(op => renderOpCard(op, activeList));
+
+      const rest = (data.operations || []).filter(op => op.status !== 'active' && op.status !== 'queued');
+      rest.forEach(op => renderOpCard(op, historyList));
+    } else {
+      // Status filter active: show all results in the appropriate section
+      const active = (data.operations || []).filter(op => op.status === 'active' || op.status === 'queued');
+      const rest = (data.operations || []).filter(op => op.status !== 'active' && op.status !== 'queued');
+
+      if (active.length === 0) {
+        activeList.innerHTML = '<div style="padding:8px 12px;color:var(--fg2);font-size:13px;">No active operations</div>';
+      }
+      active.forEach(op => renderOpCard(op, activeList));
+      rest.forEach(op => renderOpCard(op, historyList));
+    }
+
+    document.getElementById('load-more').style.display = currentOffset < totalOps ? '' : 'none';
+
+    // Update stats from dedicated endpoint
+    try {
+      const statsResp = await fetch('/api/stats');
+      const stats = await statsResp.json();
+      document.getElementById('stat-active').textContent = `Active: ${(stats.active || 0) + (stats.queued || 0)}`;
+      document.getElementById('stat-completed').textContent = `Completed: ${stats.completed || 0}`;
+      document.getElementById('stat-failed').textContent = `Failed: ${stats.failed || 0}`;
+    } catch(e) {
+      document.getElementById('stat-active').textContent = `Active: ${activeOps.length}`;
+    }
   } catch(e) {
-    document.getElementById('stat-active').textContent = `Active: ${active.length}`;
+    document.getElementById('stat-active').textContent = 'Active: 0';
+    document.getElementById('stat-completed').textContent = 'Completed: 0';
+    document.getElementById('stat-failed').textContent = 'Failed: 0';
   }
 }
 


### PR DESCRIPTION
## What
Fix active/queued operations not showing in the dashboard Active section when buried in pagination.

## Why
loadOps() fetched /api/ops?limit=20 (sorted by ID descending), then filtered active ops from the result. If an active op ID sorted lower than the top 20 completed ops, it would not appear.

## Changes
- static/app.js: Refactored loadOps() to fetch active and queued ops via separate dedicated API calls (?status=active and ?status=queued) using Promise.all for parallel execution. The main paginated call is now used only for the history list.
- main_test.go: Added status=active and status=queued filter test cases to TestHandleOps.

## How to Test
1. Create 20+ completed operations and 1 active operation with an older ID
2. Open the dashboard - the active op should always appear in the Active section
3. Run go test ./... - all 9 tests pass