### PR TITLE
feat(input): support Shift+Enter for newline in copilot session

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,21 @@ function getOrCreateTerminal(rt) {
     const s = terminals[rt];
     if (s && s.ws && s.ws.readyState === WebSocket.OPEN) s.ws.send(data);
   });
+  // Shift+Enter -> send LF (\n) instead of CR (\r) so the Copilot CLI input
+  // treats it as an in-line newline rather than submitting the message.
+  // Plain Enter keeps the default xterm behavior (sends \r -> submit).
+  // Skip while an IME composition is in progress so confirming a CJK
+  // candidate with Enter never accidentally submits or injects \n.
+  t.attachCustomKeyEventHandler(e => {
+    if (e.type !== 'keydown') return true;
+    if (e.isComposing || e.keyCode === 229) return true;
+    if (e.key === 'Enter' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      const s = terminals[rt];
+      if (s && s.ws && s.ws.readyState === WebSocket.OPEN) s.ws.send('\n');
+      return false;
+    }
+    return true;
+  });
   terminals[rt] = { term:t, fitAddon:fa, ws:null, closeTimer:null, div };
   return terminals[rt];
 }


### PR DESCRIPTION
## What
Make Shift+Enter insert a newline (instead of submitting) inside the dashboard's embedded Copilot session.

## Why
The Copilot session input is an xterm.js terminal piped to the CLI's PTY. Pressing Enter sends `\r` (CR), which the CLI treats as *submit*. Native terminals that emit `\n` on Shift+Enter let users compose multi-line prompts; the web dashboard previously could not, since xterm.js sends CR for both Enter and Shift+Enter.

## Changes
- **static/app.js**: register an ttachCustomKeyEventHandler on each per-runtime terminal.
  - On keydown, if Shift+Enter (no Ctrl/Alt/Meta) and not in IME composition, send `\n` (LF) over the WebSocket and suppress the default `\r`.
  - Skip override during IME composition (.isComposing === true or .keyCode === 229) so confirming a CJK candidate with Enter never submits or injects `\n`.
  - Plain Enter is untouched -> xterm sends `\r` -> CLI submits (existing behavior preserved).

## How to Test
1. `go build` and run the dashboard.
2. Open a Copilot session in the browser.
3. Type some text, press **Enter** -> message submits (unchanged).
4. Type some text, press **Shift+Enter** -> input wraps to a new line, no submission; continue typing and press **Enter** to submit the multi-line message.
5. With a CJK IME, type pinyin, press **Enter** to confirm the candidate -> only the candidate is committed; nothing is submitted and no extra newline is injected.