### PR TITLE
fix(session): add container padding to prevent text overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -60,12 +60,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 .xterm-helper-textarea { position: absolute !important; opacity: 0 !important; left: 0 !important; top: 0 !important; width: 1px !important; height: 1px !important; overflow: hidden !important; }
 
 /* Detail view */
-#detail-view { width: 100%; height: 100%; overflow-y: auto; padding: 20px; display: none; }
+#detail-view { width: 100%; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 20px; display: none; min-width: 0; overflow-wrap: anywhere; }
 #detail-view.visible { display: block; }
-.detail-field { margin-bottom: 16px; }
+.detail-field { margin-bottom: 16px; min-width: 0; }
 .detail-label { font-size: 11px; text-transform: uppercase; color: var(--fg2); margin-bottom: 4px; letter-spacing: 0.5px; }
-.detail-value { font-size: 14px; line-height: 1.6; }
-.detail-value pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+.detail-value { font-size: 14px; line-height: 1.6; overflow-wrap: anywhere; word-break: break-word; }
+.detail-value pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-word; max-width: 100%; }
 
 /* File tabs */
 .file-tabs { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
@@ -74,14 +74,23 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 .file-tab.active { background: var(--bg3); color: var(--fg); border-color: var(--border); }
 
 /* Rendered markdown */
-.md-content { line-height: 1.7; }
+.md-content { line-height: 1.7; overflow-wrap: anywhere; word-break: break-word; }
 .md-content h1, .md-content h2, .md-content h3 { margin: 16px 0 8px; color: var(--fg); }
-.md-content code { background: var(--bg3); padding: 2px 6px; border-radius: 4px; font-size: 13px; }
-.md-content pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; }
+.md-content code { background: var(--bg3); padding: 2px 6px; border-radius: 4px; font-size: 13px; overflow-wrap: anywhere; word-break: break-word; }
+.md-content pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; max-width: 100%; }
 .md-content pre code { background: none; padding: 0; }
-.md-content a { color: var(--accent); }
+.md-content a { color: var(--accent); overflow-wrap: anywhere; word-break: break-word; }
 .md-content ul, .md-content ol { padding-left: 24px; }
 .md-content blockquote { border-left: 3px solid var(--border); padding-left: 12px; color: var(--fg2); }
+.md-content img { max-width: 100%; height: auto; }
+.md-content table { display: block; max-width: 100%; overflow-x: auto; border-collapse: collapse; margin: 8px 0; }
+.md-content th, .md-content td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; }
+.md-content th { background: var(--bg2); font-weight: 600; }
+
+/* Narrow viewport: tighten container padding so content has room to breathe */
+@media (max-width: 600px) {
+  #detail-view { padding: 12px; }
+}
 
 /* HTML iframe */
 .html-frame { width: 100%; min-height: 500px; border: 1px solid var(--border); border-radius: 8px; background: #fff; }


### PR DESCRIPTION
## What
Add overflow-safe styling to the session detail view so long URLs, code blocks, tables, and images do not spill past the container or push the page layout wider than the viewport. Container padding is preserved on desktop and tightened for narrow viewports.

## Why
When opening a session in the dashboard, the right-pane Detail view (`#detail-view`) already had `padding: 20px`, but its inline content lacked overflow protection:
- Long unbreakable strings (URLs, hashes) in `.detail-value` (Brief / Summary) hugged the right edge.
- `.md-content pre` had `overflow-x: auto` but no `max-width: 100%`, so wide code blocks could push the layout.
- `.md-content code` (inline), tables, and images had no rules at all — wide tables and large images expanded the parent past the viewport.
- Fixed `padding: 20px` was tight on phone-sized viewports.

## Changes
- `static/style.css`:
  - `#detail-view` — add `min-width: 0`, `overflow-x: hidden`, `overflow-wrap: anywhere` so wrap rules cascade and the panel cannot expand under flex.
  - `.detail-value` — add `overflow-wrap: anywhere` + `word-break: break-word`; child `<pre>` gets `max-width: 100%`.
  - `.md-content`, `.md-content code`, `.md-content a` — add `overflow-wrap: anywhere` + `word-break: break-word` so long URLs and identifiers wrap instead of overflowing.
  - `.md-content pre` — add `max-width: 100%`.
  - `.md-content img` — `max-width: 100%; height: auto`.
  - `.md-content table` — wrap with `display: block; max-width: 100%; overflow-x: auto` and add `th/td` border + padding so wide tables scroll *inside* the panel.
  - `@media (max-width: 600px)` — tighten `#detail-view` padding to `12px`.

No HTML, JS, or Go changes. No new dependencies.

## How to Test
1. `go build ./...` (passes).
2. Run `./swat-dashboard`, open `http://localhost:<port>/`.
3. Click any operation card → Detail tab is shown.
4. Open an `OPERATION.md` containing a long URL, a wide code block, and/or a wide table.
5. Verify on desktop (≥1280px) and a narrow viewport (~360–480px, e.g. DevTools device emulation):
   - 20px (desktop) / 12px (≤600px) padding visible on all four sides of the detail content.
   - Long URLs and inline code wrap instead of overflowing.
   - Wide `<pre>`/code blocks scroll horizontally inside their container, not the page.
   - Wide tables get an internal horizontal scrollbar.
   - Images never exceed the container width.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
