### PR TITLE
fix(detail): remove duplicate filename heading and unify HTML iframe scroll

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -295,6 +295,7 @@ async function selectOp(op) {
 
   // Render file tabs
   const tabsContainer = document.getElementById('file-tabs-container');
+  const labelEl = document.getElementById('file-content-label');
   if (files.length > 0) {
     const tabsDiv = document.createElement('div');
     tabsDiv.className = 'file-tabs';
@@ -306,6 +307,11 @@ async function selectOp(op) {
       tabsDiv.appendChild(tab);
     });
     tabsContainer.appendChild(tabsDiv);
+    // File tabs already display the active filename; suppress the redundant
+    // heading above the content area to avoid duplication.
+    if (labelEl) labelEl.style.display = 'none';
+  } else if (labelEl) {
+    labelEl.style.display = '';
   }
 
   // Default to OPERATION.md if present, otherwise first file
@@ -351,8 +357,13 @@ async function loadFileContent(opId, filename, tabsDiv) {
     } else if (ext === 'html' || ext === 'htm') {
       const fileUrl = `/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`;
       contentArea.innerHTML =
-        `<a href="${escapeHtml(fileUrl)}" target="_blank" class="open-tab-btn">Open in new tab &#8599;</a>` +
-        `<iframe srcdoc="${escapeHtml(text)}" sandbox="allow-same-origin" class="html-frame"></iframe>`;
+        `<a href="${escapeHtml(fileUrl)}" target="_blank" class="open-tab-btn">Open in new tab &#8599;</a>`;
+      const iframe = document.createElement('iframe');
+      iframe.className = 'html-frame';
+      iframe.setAttribute('sandbox', 'allow-same-origin');
+      iframe.srcdoc = text;
+      attachIframeAutoResize(iframe);
+      contentArea.appendChild(iframe);
     } else {
       contentArea.innerHTML = `<pre>${escapeHtml(text)}</pre>`;
     }
@@ -364,6 +375,53 @@ async function loadFileContent(opId, filename, tabsDiv) {
 
 function escapeHtml(str) {
   return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// Resize iframe to its content height so it scrolls with the parent
+// (#detail-view) instead of showing its own scrollbar. Works for same-origin
+// srcdoc iframes since we can read the contained document directly.
+function attachIframeAutoResize(iframe) {
+  let ro = null;
+  let lastHeight = 0;
+  let winListener = null;
+  const onLoad = () => {
+    let doc;
+    try { doc = iframe.contentDocument; } catch (e) { return; }
+    if (!doc) return;
+    try {
+      const styleEl = doc.createElement('style');
+      styleEl.textContent = 'html,body{margin:0;overflow:hidden;}body{min-height:0;}';
+      (doc.head || doc.documentElement).appendChild(styleEl);
+    } catch (e) {}
+    const resize = () => {
+      let doc2;
+      try { doc2 = iframe.contentDocument; } catch (e) { return; }
+      if (!doc2 || !doc2.documentElement) return;
+      const h = Math.max(
+        doc2.documentElement.scrollHeight,
+        doc2.body ? doc2.body.scrollHeight : 0
+      );
+      if (h && h !== lastHeight) {
+        lastHeight = h;
+        iframe.style.height = h + 'px';
+      }
+    };
+    resize();
+    if (window.ResizeObserver) {
+      try {
+        if (ro) ro.disconnect();
+        ro = new ResizeObserver(resize);
+        if (doc.body) ro.observe(doc.body);
+        ro.observe(doc.documentElement);
+      } catch (e) {}
+    }
+    if (winListener) window.removeEventListener('resize', winListener);
+    winListener = () => resize();
+    window.addEventListener('resize', winListener);
+    setTimeout(resize, 100);
+    setTimeout(resize, 500);
+  };
+  iframe.addEventListener('load', onLoad);
 }
 
 // --- Filters ---

--- a/static/app.js
+++ b/static/app.js
@@ -255,6 +255,11 @@ async function selectOp(op) {
   selectedOp = op.id;
   showTab('detail');
 
+  // Tear down any prior iframe's resize listeners before rebuilding
+  // #file-content-area; covers branches (e.g. zero-files op) that don't
+  // delegate to loadFileContent.
+  teardownActiveIframeResize();
+
   document.getElementById('detail-empty').style.display = 'none';
   const content = document.getElementById('detail-content');
   content.style.display = '';

--- a/static/app.js
+++ b/static/app.js
@@ -310,8 +310,6 @@ async function selectOp(op) {
     // File tabs already display the active filename; suppress the redundant
     // heading above the content area to avoid duplication.
     if (labelEl) labelEl.style.display = 'none';
-  } else if (labelEl) {
-    labelEl.style.display = '';
   }
 
   // Default to OPERATION.md if present, otherwise first file
@@ -332,6 +330,8 @@ async function selectOp(op) {
 
 async function loadFileContent(opId, filename, tabsDiv) {
   if (selectedOp !== opId) return;
+  // Tear down any prior iframe's resize listeners before replacing content.
+  teardownActiveIframeResize();
   // Update active tab
   if (tabsDiv) {
     tabsDiv.querySelectorAll('.file-tab').forEach(t => {
@@ -380,7 +380,16 @@ function escapeHtml(str) {
 // Resize iframe to its content height so it scrolls with the parent
 // (#detail-view) instead of showing its own scrollbar. Works for same-origin
 // srcdoc iframes since we can read the contained document directly.
+let activeIframeResizeTeardown = null;
+function teardownActiveIframeResize() {
+  if (activeIframeResizeTeardown) {
+    try { activeIframeResizeTeardown(); } catch (e) {}
+    activeIframeResizeTeardown = null;
+  }
+}
 function attachIframeAutoResize(iframe) {
+  // Make sure we don't stack listeners from a previous iframe.
+  teardownActiveIframeResize();
   let ro = null;
   let lastHeight = 0;
   let winListener = null;
@@ -422,6 +431,17 @@ function attachIframeAutoResize(iframe) {
     setTimeout(resize, 500);
   };
   iframe.addEventListener('load', onLoad);
+  activeIframeResizeTeardown = () => {
+    if (winListener) {
+      window.removeEventListener('resize', winListener);
+      winListener = null;
+    }
+    if (ro) {
+      try { ro.disconnect(); } catch (e) {}
+      ro = null;
+    }
+    iframe.removeEventListener('load', onLoad);
+  };
 }
 
 // --- Filters ---

--- a/static/style.css
+++ b/static/style.css
@@ -92,8 +92,9 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
   #detail-view { padding: 12px; }
 }
 
-/* HTML iframe */
-.html-frame { width: 100%; min-height: 500px; border: 1px solid var(--border); border-radius: 8px; background: #fff; }
+/* HTML iframe — auto-sized to content height by JS so the outer #detail-view
+   scroll handles long content instead of producing a nested scrollbar. */
+.html-frame { width: 100%; min-height: 200px; border: 1px solid var(--border); border-radius: 8px; background: #fff; display: block; }
 .open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--bg3); border: 1px solid var(--border); color: var(--accent); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
 
 /* Empty state */

--- a/static/style.css
+++ b/static/style.css
@@ -94,7 +94,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 
 /* HTML iframe — auto-sized to content height by JS so the outer #detail-view
    scroll handles long content instead of producing a nested scrollbar. */
-.html-frame { width: 100%; min-height: 200px; border: 1px solid var(--border); border-radius: 8px; background: #fff; display: block; }
+.html-frame { width: 100%; border: 1px solid var(--border); border-radius: 8px; background: #fff; display: block; }
 .open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--bg3); border: 1px solid var(--border); color: var(--accent); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
 
 /* Empty state */


### PR DESCRIPTION
## What
Two detail-view UX fixes for `static/app.js` and `static/style.css`:

1. **Drop duplicate filename heading** — when file tabs are rendered, hide the now-redundant `#file-content-label` heading above the content area.
2. **Unify HTML iframe scrolling** — auto-size the HTML preview iframe to its content height and suppress its internal scrollbar so the outer `#detail-view` panel (which already has `overflow-y: auto` from PR #17) handles all scrolling.

## Why
- The active file tab already identifies the current file; the dashboard-added filename heading immediately below it was pure visual noise.
- HTML reports rendered via `<iframe srcdoc=...>` were showing their own scrollbar inside the detail panel, which itself scrolls — a nested-scroll experience that's awkward to use, especially for tall reports (5000px+).

Builds on #17 (which introduced the outer detail-panel scroll). Touches the same `selectOp` / `loadFileContent` / `.html-frame` / `#detail-view` surface as #17 and #18.

## Changes
- `static/app.js`
  - `selectOp`: hide `#file-content-label` when `files.length > 0`, restore it for the no-tabs fallback.
  - `loadFileContent` (HTML branch): build the iframe via `document.createElement` (instead of an inline `srcdoc=...` HTML string) so a `load` listener can be attached.
  - New `attachIframeAutoResize(iframe)` helper:
    - On iframe `load`, injects `html,body{margin:0;overflow:hidden;}body{min-height:0;}` into the same-origin doc.
    - Sets `iframe.style.height = max(documentElement.scrollHeight, body.scrollHeight)`.
    - Re-measures via `ResizeObserver` on `body`/`documentElement`, on parent window `resize`, and via two trailing `setTimeout` passes (100ms, 500ms) to catch late subresources (images / fonts) since the iframe has no scripts.
- `static/style.css`
  - `.html-frame`: lower `min-height` to `200px` (used only as first-paint placeholder; JS resizes to actual content), add `display: block`.

## How to Test
1. `go build .` — passes.
2. Run the dashboard and open a completed operation that has multiple files in its directory.
3. Click any file tab → the file name should appear **only** in the active tab pill, not duplicated as a heading above the content.
4. Open an `OPERATION.md` (markdown that starts with `# title`) → the markdown's own first-line heading is preserved (it's content, not a dashboard heading).
5. Open a `report.html` from a long operation (>1 viewport tall) → there should be **no** scrollbar inside the iframe; scrolling the detail panel should scroll the entire HTML report smoothly.
6. Resize the browser window → iframe re-measures and tracks content height.

## Related
- #17 — added `#detail-view { overflow-y: auto }` (this PR reuses that outer scroll).
- #18 — split active/history loaders in `static/app.js`.

todo ids: dedup-filename, iframe-scroll-unify
