### PR TITLE
fix(operation): skip YAML frontmatter when rendering OPERATION.md

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -345,7 +345,8 @@ async function loadFileContent(opId, filename, tabsDiv) {
     const ext = filename.split('.').pop().toLowerCase();
 
     if (ext === 'md' && typeof marked !== 'undefined') {
-      const rawHtml = marked.parse(text);
+      const body = typeof stripFrontmatter === 'function' ? stripFrontmatter(text) : text;
+      const rawHtml = marked.parse(body);
       const sanitized = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(rawHtml) : rawHtml;
       contentArea.innerHTML = `<div class="md-content">${sanitized}</div>`;
     } else if (ext === 'html' || ext === 'htm') {

--- a/static/frontmatter.js
+++ b/static/frontmatter.js
@@ -1,0 +1,44 @@
+// Strip a leading YAML frontmatter block from a markdown string.
+//
+// Rules:
+//   - The file must start with a line that is exactly `---` (optional trailing
+//     spaces/tabs allowed) on line 1. Otherwise the input is returned unchanged.
+//   - Stripping ends at the next standalone `---` line (also `---` with optional
+//     trailing spaces/tabs, terminated by a newline or end-of-file).
+//   - If no closing `---` line is found, the input is returned unchanged so we
+//     never silently swallow a document that just happens to start with `---`.
+//   - Horizontal-rule `---` lines anywhere other than line 1 are never stripped.
+//
+// Exposed both as a browser global (`window.stripFrontmatter`) and as a
+// CommonJS export so the same logic can be unit tested under Node.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    var api = factory();
+    root.stripFrontmatter = api.stripFrontmatter;
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  function stripFrontmatter(text) {
+    if (typeof text !== 'string' || !text.startsWith('---')) {
+      return text;
+    }
+    var nl = text.indexOf('\n');
+    if (nl === -1) {
+      // Single line that may be just `---` — not a frontmatter block.
+      return text;
+    }
+    var firstLine = text.slice(0, nl).replace(/\r$/, '');
+    if (!/^---[ \t]*$/.test(firstLine)) {
+      return text;
+    }
+    var rest = text.slice(nl + 1);
+    var closer = /(?:^|\n)---[ \t]*(?:\r?\n|$)/.exec(rest);
+    if (!closer) {
+      return text;
+    }
+    return rest.slice(closer.index + closer[0].length);
+  }
+
+  return { stripFrontmatter: stripFrontmatter };
+}));

--- a/static/frontmatter.test.js
+++ b/static/frontmatter.test.js
@@ -1,0 +1,62 @@
+// Edge-case tests for stripFrontmatter.
+// Run with: node static/frontmatter.test.js
+//
+// Uses Node's built-in node:test runner (Node >= 18) so no external deps.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { stripFrontmatter } = require('./frontmatter');
+
+test('(a) no frontmatter is returned unchanged', () => {
+  const input = '# Title\n\nSome body text.\n';
+  assert.equal(stripFrontmatter(input), input);
+});
+
+test('(b) leading frontmatter block is stripped', () => {
+  const input = '---\ntitle: Hello\nsummary: |\n  multi-line\n---\n# Body\n\nText.\n';
+  assert.equal(stripFrontmatter(input), '# Body\n\nText.\n');
+});
+
+test('(c) body containing --- horizontal rule is not stripped', () => {
+  const input = '# Title\n\nIntro.\n\n---\n\nMore body.\n';
+  assert.equal(stripFrontmatter(input), input);
+});
+
+test('(d) frontmatter only, no body, returns empty', () => {
+  const input = '---\nkey: value\n---\n';
+  assert.equal(stripFrontmatter(input), '');
+});
+
+test('(d2) frontmatter only with no trailing newline', () => {
+  const input = '---\nkey: value\n---';
+  assert.equal(stripFrontmatter(input), '');
+});
+
+test('(e) unterminated frontmatter returns input unchanged', () => {
+  const input = '---\nkey: value\nno closer here\n';
+  assert.equal(stripFrontmatter(input), input);
+});
+
+test('opening line with trailing spaces is treated as frontmatter', () => {
+  const input = '---  \nkey: value\n---\nbody\n';
+  assert.equal(stripFrontmatter(input), 'body\n');
+});
+
+test('opening line that is not exactly --- is left untouched', () => {
+  const input = '----\nnot frontmatter\n----\nbody\n';
+  assert.equal(stripFrontmatter(input), input);
+});
+
+test('CRLF line endings are handled', () => {
+  const input = '---\r\nkey: v\r\n---\r\n# Body\r\n';
+  assert.equal(stripFrontmatter(input), '# Body\r\n');
+});
+
+test('non-string input is returned unchanged', () => {
+  assert.equal(stripFrontmatter(null), null);
+  assert.equal(stripFrontmatter(undefined), undefined);
+});
+
+test('single line --- with no newline is not treated as frontmatter', () => {
+  assert.equal(stripFrontmatter('---'), '---');
+});

--- a/static/index.html
+++ b/static/index.html
@@ -67,6 +67,7 @@
 <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.1/dist/purify.min.js"></script>
+<script src="frontmatter.js"></script>
 <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What
Strip the leading YAML frontmatter block from `OPERATION.md` (and any other markdown file) before passing it to `marked.parse`, so the dashboard no longer renders raw YAML metadata (`operation_id:`, `summary: |`, etc.) at the top of the operation detail view.

## Why
Operation files start with a `--- ... ---` frontmatter block consumed by SWAT itself. The dashboard was forwarding the entire file to `marked`, leaving that block visible to users (see swat-review op `20260428-cde46d8c` for the bug evidence). Per brief, field parsing stays SWAT's responsibility  this PR only suppresses the block from the rendered markdown body.

## Changes
- `static/frontmatter.js`  new UMD-style helper exposing `stripFrontmatter`, usable both as a browser global and a CommonJS module for unit tests.
- `static/frontmatter.test.js`  11 cases using Node's built-in `node:test` runner, covering all five required edge cases:
  - (a) no frontmatter  unchanged
  - (b) leading frontmatter  stripped
  - (c) body containing `---` horizontal rule  unchanged
  - (d) frontmatter only, no body  empty
  - (e) unterminated frontmatter  unchanged (never silently swallow content)
  - plus CRLF, trailing-space-on-fence, `----` (not a fence), and non-string inputs.
- `static/index.html`  load `frontmatter.js` before `app.js`.
- `static/app.js`  call `stripFrontmatter(text)` before `marked.parse`.

## How to Test
1. `node static/frontmatter.test.js`  11 passing assertions.
2. Open the dashboard, select any operation; the rendered `OPERATION.md` no longer shows the leading YAML block, while body horizontal rules (`---`) are preserved.

## Related
- Fixes the symptom captured in swat-review op `20260428-cde46d8c`.
- Brief todo id: `skip-frontmatter`.
- Operation: `20260428-9c6d7466`.
