### PR TITLE
fix(operation): parse YAML frontmatter properly when rendering OPERATION.md

### DIFF
--- a/frontmatter.go
+++ b/frontmatter.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+// splitFrontmatter separates a leading YAML frontmatter block from the body.
+//
+// A frontmatter block must:
+//   - Start at the very first byte of the document with `---` followed by an
+//     end-of-line (LF or CRLF). Any leading whitespace, BOM, or non-`---` byte
+//     means there is no frontmatter.
+//   - Be terminated by a line containing exactly `---` (optionally with
+//     trailing CR) before EOF.
+//
+// On success it returns (yamlBlock, body, true). yamlBlock excludes the
+// surrounding `---` delimiters; body is everything after the closing delimiter
+// (including its trailing newline if any).
+//
+// On any of the following it returns (nil, content, false) so callers can
+// safely fall back to treating the whole document as body:
+//   - The document does not start with a `---` line.
+//   - The opening `---` line is never closed by another standalone `---`.
+//   - A `---` later in the body must NOT be treated as a closing delimiter
+//     when there was no opening delimiter (the leading-byte check guarantees
+//     this).
+func splitFrontmatter(content []byte) (yamlBlock, body []byte, ok bool) {
+	const delim = "---"
+
+	// Must start with `---` followed by LF or CRLF (or be exactly `---`+EOF).
+	if !bytes.HasPrefix(content, []byte(delim)) {
+		return nil, content, false
+	}
+	rest := content[len(delim):]
+	// The character immediately after `---` must be \n or \r (CRLF). If the
+	// document is just `---` with no terminator, that is also not a valid
+	// (closed) frontmatter block.
+	if len(rest) == 0 {
+		return nil, content, false
+	}
+	switch rest[0] {
+	case '\n':
+		rest = rest[1:]
+	case '\r':
+		if len(rest) > 1 && rest[1] == '\n' {
+			rest = rest[2:]
+		} else {
+			rest = rest[1:]
+		}
+	default:
+		// e.g. "---foo" — not a frontmatter delimiter.
+		return nil, content, false
+	}
+
+	// Walk line-by-line looking for a standalone `---` line.
+	cursor := 0
+	for cursor < len(rest) {
+		// Find end of current line.
+		nl := bytes.IndexByte(rest[cursor:], '\n')
+		var line []byte
+		var lineEnd int // index in rest just past the line terminator
+		if nl < 0 {
+			line = rest[cursor:]
+			lineEnd = len(rest)
+		} else {
+			line = rest[cursor : cursor+nl]
+			lineEnd = cursor + nl + 1
+		}
+		// Strip a single trailing CR for CRLF files.
+		trimmed := line
+		if n := len(trimmed); n > 0 && trimmed[n-1] == '\r' {
+			trimmed = trimmed[:n-1]
+		}
+		if bytes.Equal(trimmed, []byte(delim)) {
+			yamlBlock = rest[:cursor]
+			body = rest[lineEnd:]
+			return yamlBlock, body, true
+		}
+		cursor = lineEnd
+	}
+
+	// Unterminated frontmatter — treat whole file as body, untouched.
+	return nil, content, false
+}
+
+// parseFrontmatter splits the document and unmarshals the YAML block.
+//
+// If there is no valid frontmatter, it returns (nil, original-content, false).
+// If the YAML fails to parse, it returns (nil, body, true) — callers still
+// see the body without the raw YAML, and can fall back for missing fields.
+func parseFrontmatter(content []byte) (meta map[string]any, body string, ok bool) {
+	yamlBlock, bodyBytes, hasFM := splitFrontmatter(content)
+	if !hasFM {
+		return nil, string(content), false
+	}
+	if len(bytes.TrimSpace(yamlBlock)) == 0 {
+		return map[string]any{}, string(bodyBytes), true
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(yamlBlock, &m); err != nil {
+		return nil, string(bodyBytes), true
+	}
+	return m, string(bodyBytes), true
+}
+
+// frontmatterString returns meta[key] as a string if present and string-typed,
+// else "". This deliberately ignores non-string values (numbers, maps, etc.)
+// so block-scalar markers (`|`, `>`) cannot leak: a real YAML parser already
+// resolved them into a plain Go string.
+func frontmatterString(meta map[string]any, key string) string {
+	if meta == nil {
+		return ""
+	}
+	v, ok := meta[key]
+	if !ok || v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/frontmatter.go
+++ b/frontmatter.go
@@ -122,3 +122,24 @@ func frontmatterString(meta map[string]any, key string) string {
 	}
 	return ""
 }
+
+// needsFrontmatterReparse reports whether a string field looks like it still
+// carries a raw YAML block-scalar indicator (`|` or `>`, optionally followed
+// by chomping/indent indicators). When the upstream operation package returns
+// such a value verbatim, callers must re-parse OPERATION.md with a real YAML
+// parser; otherwise the leading marker would leak into the UI.
+//
+// Returns false for plain strings (the common case) so callers can skip the
+// expensive file-read + YAML parse on every list call.
+func needsFrontmatterReparse(s string) bool {
+	// Strip leading horizontal whitespace; a YAML scalar may be written as
+	// `summary:   |` and the upstream package may or may not trim that.
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	if i >= len(s) {
+		return false
+	}
+	return s[i] == '|' || s[i] == '>'
+}

--- a/frontmatter_test.go
+++ b/frontmatter_test.go
@@ -180,3 +180,30 @@ func TestFrontmatterString_NonStringIgnored(t *testing.T) {
 		t.Errorf("nil meta returned %q", got)
 	}
 }
+
+func TestNeedsFrontmatterReparse(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain text", "all good here", false},
+		{"plain with newline", "line one\nline two", false},
+		{"literal block marker", "|\n  multi\n  line", true},
+		{"folded block marker", ">\n  multi\n  line", true},
+		{"literal with chomping", "|-\n  trimmed", true},
+		{"folded with keep", ">+\n  kept\n", true},
+		{"leading whitespace then marker", "   |\n  body", true},
+		{"leading tab then marker", "\t>\n  body", true},
+		{"only whitespace", "   \t  ", false},
+		{"marker not at start", "see |x|", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsFrontmatterReparse(tc.in); got != tc.want {
+				t.Errorf("needsFrontmatterReparse(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/frontmatter_test.go
+++ b/frontmatter_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Edge cases (a)–(g) from the brief.
+
+func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	// (a) No frontmatter at all — body returned untouched, ok=false.
+	in := []byte("# Hello\n\nbody text\n")
+	yml, body, ok := splitFrontmatter(in)
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+	if yml != nil {
+		t.Errorf("yaml block = %q, want nil", yml)
+	}
+	if string(body) != string(in) {
+		t.Errorf("body = %q, want %q", body, in)
+	}
+}
+
+func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
+	// (b) Frontmatter present.
+	in := []byte("---\nsummary: hi\n---\n# Title\n\nbody\n")
+	yml, body, ok := splitFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if string(yml) != "summary: hi\n" {
+		t.Errorf("yaml = %q", yml)
+	}
+	if string(body) != "# Title\n\nbody\n" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitFrontmatter_BodyHasHorizontalRule(t *testing.T) {
+	// (c) Body contains `---` as a horizontal rule. The leading-byte check
+	// guarantees we never strip when no opening delimiter exists.
+	in := []byte("# Title\n\npara 1\n\n---\n\npara 2\n")
+	yml, body, ok := splitFrontmatter(in)
+	if ok {
+		t.Fatalf("ok = true, want false (no leading frontmatter)")
+	}
+	if yml != nil {
+		t.Errorf("yaml = %q, want nil", yml)
+	}
+	if string(body) != string(in) {
+		t.Errorf("body altered; got %q want %q", body, in)
+	}
+}
+
+func TestSplitFrontmatter_FrontmatterOnlyNoBody(t *testing.T) {
+	// (d) Frontmatter only, no body content after closing delimiter.
+	in := []byte("---\nsummary: solo\n---\n")
+	yml, body, ok := splitFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if string(yml) != "summary: solo\n" {
+		t.Errorf("yaml = %q", yml)
+	}
+	if string(body) != "" {
+		t.Errorf("body = %q, want empty", body)
+	}
+}
+
+func TestSplitFrontmatter_Unterminated(t *testing.T) {
+	// (e) Opening `---` never closed — leave content untouched.
+	in := []byte("---\nsummary: forever\nbody but no closing\n")
+	yml, body, ok := splitFrontmatter(in)
+	if ok {
+		t.Fatalf("ok = true, want false (unterminated must not be stripped)")
+	}
+	if yml != nil {
+		t.Errorf("yaml = %q, want nil", yml)
+	}
+	if string(body) != string(in) {
+		t.Errorf("body = %q, want untouched %q", body, in)
+	}
+}
+
+func TestParseFrontmatter_LiteralBlockScalar(t *testing.T) {
+	// (f) summary written with `|` literal block scalar — parser must resolve
+	// it; the `|` must NOT appear in the result.
+	in := []byte("---\nsummary: |\n  line one\n  line two\n---\nbody\n")
+	meta, body, ok := parseFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	got := frontmatterString(meta, "summary")
+	if strings.Contains(got, "|") {
+		t.Errorf("summary leaked block-scalar marker: %q", got)
+	}
+	if got != "line one\nline two\n" {
+		t.Errorf("summary = %q, want %q", got, "line one\nline two\n")
+	}
+	if body != "body\n" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestParseFrontmatter_FoldedBlockScalar(t *testing.T) {
+	// (g) summary written with `>` folded block scalar.
+	in := []byte("---\nsummary: >\n  line one\n  line two\n---\nbody\n")
+	meta, _, ok := parseFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	got := frontmatterString(meta, "summary")
+	if strings.Contains(got, ">") {
+		t.Errorf("summary leaked fold marker: %q", got)
+	}
+	// Folded scalar collapses internal newlines into spaces.
+	if got != "line one line two\n" {
+		t.Errorf("summary = %q, want %q", got, "line one line two\n")
+	}
+}
+
+// Additional sanity tests beyond the brief.
+
+func TestSplitFrontmatter_CRLF(t *testing.T) {
+	in := []byte("---\r\nsummary: hi\r\n---\r\nbody\r\n")
+	yml, body, ok := splitFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok=false")
+	}
+	if string(yml) != "summary: hi\r\n" {
+		t.Errorf("yaml = %q", yml)
+	}
+	if string(body) != "body\r\n" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitFrontmatter_NotADelimiterPrefix(t *testing.T) {
+	// `---foo` on the first line is not a delimiter.
+	in := []byte("---foo\nbody\n")
+	_, body, ok := splitFrontmatter(in)
+	if ok {
+		t.Fatalf("ok=true for non-delimiter prefix")
+	}
+	if string(body) != string(in) {
+		t.Errorf("body altered")
+	}
+}
+
+func TestParseFrontmatter_EmptyFrontmatter(t *testing.T) {
+	in := []byte("---\n---\nbody\n")
+	meta, body, ok := parseFrontmatter(in)
+	if !ok {
+		t.Fatalf("ok=false")
+	}
+	if meta == nil {
+		t.Errorf("meta=nil, want empty map")
+	}
+	if len(meta) != 0 {
+		t.Errorf("meta=%v, want empty", meta)
+	}
+	if body != "body\n" {
+		t.Errorf("body=%q", body)
+	}
+}
+
+func TestFrontmatterString_NonStringIgnored(t *testing.T) {
+	meta := map[string]any{"summary": 42, "brief": "hello"}
+	if got := frontmatterString(meta, "summary"); got != "" {
+		t.Errorf("non-string returned %q, want empty", got)
+	}
+	if got := frontmatterString(meta, "brief"); got != "hello" {
+		t.Errorf("brief = %q", got)
+	}
+	if got := frontmatterString(meta, "missing"); got != "" {
+		t.Errorf("missing key = %q, want empty", got)
+	}
+	if got := frontmatterString(nil, "summary"); got != "" {
+		t.Errorf("nil meta returned %q", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/gorilla/websocket v1.5.3
 )
 
+require gopkg.in/yaml.v3 v3.0.1
+
 require (
 	github.com/LangSensei/swat v1.1.3
 	github.com/UserExistsError/conpty v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,7 @@ github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -56,6 +56,22 @@ func opToView(op *operation.Operation) OpView {
 		Brief:   op.Brief,
 		Summary: op.Summary,
 	}
+	// Re-parse OPERATION.md frontmatter with a real YAML parser so block-
+	// scalar markers (`|`, `>`) and other YAML literals never leak into the
+	// UI. Falls back to the upstream-provided value on any error.
+	if home, err := os.UserHomeDir(); err == nil {
+		opMD := filepath.Join(home, ".swat", "squads", op.Squad, "operations", op.OperationID, "OPERATION.md")
+		if data, err := os.ReadFile(opMD); err == nil {
+			if meta, _, ok := parseFrontmatter(data); ok {
+				if s := frontmatterString(meta, "summary"); s != "" {
+					v.Summary = s
+				}
+				if s := frontmatterString(meta, "brief"); s != "" {
+					v.Brief = s
+				}
+			}
+		}
+	}
 	if !op.CreatedAt.IsZero() {
 		v.CreatedAt = op.CreatedAt.Format(time.RFC3339)
 	}
@@ -329,6 +345,13 @@ func handleOpFile(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "not found", 404)
 		return
+	}
+	// For OPERATION.md, strip the leading YAML frontmatter so the renderer
+	// (marked.js on the frontend) does not display the raw metadata block.
+	if file == "OPERATION.md" {
+		if _, body, ok := parseFrontmatter([]byte(content)); ok {
+			content = body
+		}
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Write([]byte(content))

--- a/main.go
+++ b/main.go
@@ -56,18 +56,21 @@ func opToView(op *operation.Operation) OpView {
 		Brief:   op.Brief,
 		Summary: op.Summary,
 	}
-	// Re-parse OPERATION.md frontmatter with a real YAML parser so block-
-	// scalar markers (`|`, `>`) and other YAML literals never leak into the
-	// UI. Falls back to the upstream-provided value on any error.
-	if home, err := os.UserHomeDir(); err == nil {
-		opMD := filepath.Join(home, ".swat", "squads", op.Squad, "operations", op.OperationID, "OPERATION.md")
-		if data, err := os.ReadFile(opMD); err == nil {
-			if meta, _, ok := parseFrontmatter(data); ok {
-				if s := frontmatterString(meta, "summary"); s != "" {
-					v.Summary = s
-				}
-				if s := frontmatterString(meta, "brief"); s != "" {
-					v.Brief = s
+	// The upstream operation package returns Brief/Summary as raw YAML
+	// strings; if the YAML used a block-scalar (`|` / `>`) the marker can
+	// leak into the UI. Re-parse OPERATION.md with a real YAML parser only
+	// when one of the fields actually shows that pattern — this avoids an
+	// N+1 file read on every list call for the common (already-clean) case.
+	if needsFrontmatterReparse(v.Brief) || needsFrontmatterReparse(v.Summary) {
+		if dir, err := opDirForSquad(op.Squad, op.OperationID); err == nil {
+			if data, err := os.ReadFile(filepath.Join(dir, "OPERATION.md")); err == nil {
+				if meta, _, ok := parseFrontmatter(data); ok {
+					if s := frontmatterString(meta, "summary"); s != "" {
+						v.Summary = s
+					}
+					if s := frontmatterString(meta, "brief"); s != "" {
+						v.Brief = s
+					}
 				}
 			}
 		}
@@ -288,14 +291,26 @@ func handleSquads(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(listSquads())
 }
 
+// opDirForSquad returns the on-disk directory for an operation given its
+// squad. This is the single source of truth for the
+// `~/.swat/squads/<squad>/operations/<id>` convention; both opDir and
+// opToView share it so any future `swat home` refactor only needs to
+// touch one place.
+func opDirForSquad(squad, opID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".swat", "squads", squad, "operations", opID), nil
+}
+
 // opDir returns the filesystem path for a given operation ID.
 func opDir(opID string) (string, error) {
 	op, err := operation.Find(opID)
 	if err != nil {
 		return "", err
 	}
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".swat", "squads", op.Squad, "operations", opID), nil
+	return opDirForSquad(op.Squad, opID)
 }
 
 // handleOpFiles returns a JSON array of non-hidden file names in the operation directory.


### PR DESCRIPTION
## What
Use a real YAML parser for OPERATION.md so the dashboard no longer renders the leading frontmatter block as part of the Markdown body, and never leaks YAML block-scalar markers (`|`, `>`) into the `summary` field.

## Why
- Opening an operation detail page rendered the entire `---`-bounded YAML metadata block verbatim through marked.js (the `---` lines became horizontal rules, the keys became literal text).
- The `summary` field surfaced as raw YAML — for ops using `summary: |` or `summary: >`, the literal/folded markers leaked into the UI (see op `20260428-cde46d8c`). Root cause: extraction was not going through a real YAML parser.

todo id: `skip-frontmatter`

## Changes
- `frontmatter.go` (new):
  - `splitFrontmatter` — only strips when the file starts with `---` on line 1 followed by a real EOL, ending at the next standalone `---` line. Never touches body horizontal rules. Leaves unterminated frontmatter completely untouched.
  - `parseFrontmatter` — unmarshals the YAML block via `gopkg.in/yaml.v3` so block scalars resolve to plain Go strings.
  - `frontmatterString` — only returns string-typed values (numbers/maps/etc. → "") so type fallbacks cannot leak markers.
- `main.go`:
  - `handleOpFile` strips the frontmatter from `/api/file?file=OPERATION.md` responses, so the frontend's `marked.parse` only sees the body.
  - `opToView` re-reads `OPERATION.md` and overrides `Summary`/`Brief` from the parsed YAML map, falling back to the upstream-provided values on any error.
- `frontmatter_test.go` (new): all 7 edge cases from the brief plus CRLF, non-delimiter prefix, empty frontmatter, and non-string field handling.
- `go.mod` / `go.sum`: add `gopkg.in/yaml.v3 v3.0.1`.

## How to Test
```bash
go test ./...
```
All `TestSplitFrontmatter_*` / `TestParseFrontmatter_*` / `TestFrontmatterString_*` tests cover:
- (a) no frontmatter
- (b) frontmatter present
- (c) body contains `---` HR
- (d) frontmatter only, no body
- (e) unterminated frontmatter (must NOT be stripped)
- (f) `summary: |` literal block scalar
- (g) `summary: >` folded block scalar

Manual: open any operation in the dashboard whose OPERATION.md uses `summary: |` (e.g. `20260428-cde46d8c`). Summary should render as plain text without the `|`, and the rendered OPERATION.md tab should start at the body title, not at `---`.
