### PR TITLE
feat(runtime): single-active runtime ownership with persistent --resume sessions

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -37,6 +37,18 @@ func (b *Broadcaster) Unsubscribe(id int) {
 	}
 }
 
+// CloseAll drops every subscriber so existing WS goroutines unblock and
+// return. Used by the runtime switch path so old WS clients receive close
+// frames and reconnect against the new active runtime.
+func (b *Broadcaster) CloseAll() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for id, ch := range b.clients {
+		close(ch)
+		delete(b.clients, id)
+	}
+}
+
 func (b *Broadcaster) broadcast(data []byte) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -60,6 +72,16 @@ func (b *Broadcaster) Start(pty *platformPTY, onExit func()) {
 	b.running = true
 	b.mu.Unlock()
 
+	// Wrap onExit in sync.Once so an explicit teardown (e.g. runtime switch)
+	// followed by the PTY-EOF path does not double-invoke cleanup and
+	// double-delete from the sessions/broadcasters maps.
+	var once sync.Once
+	fire := func() {
+		if onExit != nil {
+			once.Do(onExit)
+		}
+	}
+
 	go func() {
 		buf := make([]byte, 4096)
 		for {
@@ -69,9 +91,7 @@ func (b *Broadcaster) Start(pty *platformPTY, onExit func()) {
 			}
 			if err != nil {
 				b.broadcast([]byte("\r\n[Session ended]"))
-				if onExit != nil {
-					onExit()
-				}
+				fire()
 				return
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.24.1
 
 require (
 	github.com/creack/pty v1.1.24
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPV
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/main.go
+++ b/main.go
@@ -276,6 +276,23 @@ func getOrCreateSession(runtimeName, prompt string) (*platformPTY, *Broadcaster,
 		return sess, broadcasters[runtimeName], nil
 	}
 
+	// Re-check active runtime under sessionsMu to seal the residual race
+	// window in handleSessionWS between its pre-upgrade `rt != active`
+	// check and this call: an in-flight WS upgrader that already passed
+	// the pre-check can be context-switched out long enough for
+	// handleRuntimeSwitch to flip SetActive(to); without this gate it
+	// would resume here and spawn a fresh PTY for the now-outgoing
+	// runtime, violating the single-active-runtime invariant. Safe for
+	// all three call sites: the WS upgrade rejects late races,
+	// handleRuntimeSwitch's spawnSessionFn proceeds because SetActive(to)
+	// already ran, and autoStartActiveSession proceeds for the active
+	// runtime it just selected.
+	if sessionStore != nil {
+		if active := sessionStore.ActiveRuntime(); active != "" && active != runtimeName {
+			return nil, nil, fmt.Errorf("runtime %q is not active (active=%q)", runtimeName, active)
+		}
+	}
+
 	if prompt == "" {
 		prompt = defaultPrompt
 	}
@@ -552,10 +569,12 @@ func handleRuntimeSwitch(w http.ResponseWriter, r *http.Request) {
 
 	// IMPORTANT: SetActive(to) MUST happen before the outgoing PTY teardown.
 	// handleSessionWS rejects upgrades whose runtime != active BEFORE
-	// upgrading, so flipping the active marker first guarantees that any WS
-	// connection arriving for `current` during the multi-second teardown
-	// window cannot race ahead and respawn an orphan PTY for the outgoing
-	// runtime (preserving the single-active-runtime invariant). If
+	// upgrading, and getOrCreateSession re-checks under sessionsMu, so
+	// flipping the active marker first guarantees that any WS connection
+	// arriving for `current` during the multi-second teardown window
+	// cannot race ahead and respawn an orphan PTY for the outgoing
+	// runtime (preserving the single-active-runtime invariant — both the
+	// pre-upgrade gate and the post-lock gate must agree). If
 	// SetActive fails we abort cleanly with the old PTY still intact.
 	if err := sessionStore.SetActive(to); err != nil {
 		log.Printf("handleRuntimeSwitch: persist active=%s: %v", to, err)

--- a/main.go
+++ b/main.go
@@ -256,6 +256,18 @@ var (
 // fallback (and by /api/runtimes for stable client rendering).
 var runtimeOrder = []string{"copilot", "gemini"}
 
+// Test-only hooks. These are package vars so individual tests can override
+// them to exercise concurrency-sensitive paths without depending on a real
+// CLI being installed. Production callers are unaffected.
+var (
+	lookPathFn     = exec.LookPath
+	terminatePTYFn = func(p *platformPTY, d time.Duration) { p.Terminate(d) }
+	spawnSessionFn = func(rt string) error {
+		_, _, err := getOrCreateSession(rt, defaultPrompt)
+		return err
+	}
+)
+
 func getOrCreateSession(runtimeName, prompt string) (*platformPTY, *Broadcaster, error) {
 	sessionsMu.Lock()
 	defer sessionsMu.Unlock()
@@ -533,12 +545,25 @@ func handleRuntimeSwitch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if _, err := exec.LookPath(to); err != nil {
+	if _, err := lookPathFn(to); err != nil {
 		http.Error(w, fmt.Sprintf("%s CLI not available on PATH", to), http.StatusBadRequest)
 		return
 	}
 
-	// Tear down the currently-active PTY (if any). We snapshot under
+	// IMPORTANT: SetActive(to) MUST happen before the outgoing PTY teardown.
+	// handleSessionWS rejects upgrades whose runtime != active BEFORE
+	// upgrading, so flipping the active marker first guarantees that any WS
+	// connection arriving for `current` during the multi-second teardown
+	// window cannot race ahead and respawn an orphan PTY for the outgoing
+	// runtime (preserving the single-active-runtime invariant). If
+	// SetActive fails we abort cleanly with the old PTY still intact.
+	if err := sessionStore.SetActive(to); err != nil {
+		log.Printf("handleRuntimeSwitch: persist active=%s: %v", to, err)
+		http.Error(w, "failed to persist new active runtime", http.StatusInternalServerError)
+		return
+	}
+
+	// Tear down the previously-active PTY (if any). We snapshot under
 	// sessionsMu but call Terminate / CloseAll outside the lock — Terminate
 	// can block for several seconds and we don't want to block other
 	// session-map readers (e.g. /api/runtimes).
@@ -550,19 +575,13 @@ func handleRuntimeSwitch(w http.ResponseWriter, r *http.Request) {
 	sessionsMu.Unlock()
 
 	if curSess != nil {
-		curSess.Terminate(3 * time.Second)
+		terminatePTYFn(curSess, 3*time.Second)
 	}
 	if curBc != nil {
 		curBc.CloseAll()
 	}
 
-	if err := sessionStore.SetActive(to); err != nil {
-		log.Printf("handleRuntimeSwitch: persist active=%s: %v", to, err)
-		http.Error(w, "failed to persist new active runtime", http.StatusInternalServerError)
-		return
-	}
-
-	if _, _, err := getOrCreateSession(to, defaultPrompt); err != nil {
+	if err := spawnSessionFn(to); err != nil {
 		log.Printf("handleRuntimeSwitch: spawn %s: %v", to, err)
 		http.Error(w, fmt.Sprintf("failed to spawn %s: %v", to, err), http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -236,10 +236,25 @@ const defaultPrompt = `You are a SWAT dashboard operator. Wait for user instruct
 // --- PTY session manager ---
 
 var (
-	sessions      = make(map[string]*platformPTY)
-	broadcasters  = make(map[string]*Broadcaster)
-	sessionsMu    sync.Mutex
+	sessions     = make(map[string]*platformPTY)
+	broadcasters = make(map[string]*Broadcaster)
+	sessionsMu   sync.Mutex
+
+	// switchMu serialises POST /api/runtime/switch. It is intentionally
+	// distinct from sessionsMu — switch runs the full tear-down + spawn dance
+	// (which acquires sessionsMu inside getOrCreateSession), so reusing
+	// sessionsMu here would deadlock. switchMu is used with TryLock so
+	// concurrent UI clicks return 409 instead of queueing.
+	switchMu sync.Mutex
+
+	// sessionStore holds the persistent runtime-id state. It is loaded once
+	// at startup.
+	sessionStore *SessionStore
 )
+
+// runtimeOrder defines the canonical ordering used by autoStartActiveSession's
+// fallback (and by /api/runtimes for stable client rendering).
+var runtimeOrder = []string{"copilot", "gemini"}
 
 func getOrCreateSession(runtimeName, prompt string) (*platformPTY, *Broadcaster, error) {
 	sessionsMu.Lock()
@@ -270,22 +285,48 @@ func getOrCreateSession(runtimeName, prompt string) (*platformPTY, *Broadcaster,
 	return sess, bc, nil
 }
 
-func autoStartSessions() {
-	for _, rt := range []string{"copilot", "gemini"} {
-		if _, err := exec.LookPath(rt); err == nil {
-			_, _, err := getOrCreateSession(rt, defaultPrompt)
-			if err != nil {
-				log.Printf("Failed to auto-start %s: %v", rt, err)
-			} else {
-				log.Printf("Auto-started %s session", rt)
+// autoStartActiveSession spawns exactly one PTY at boot, picking the persisted
+// active runtime if its CLI is on PATH, else the first available runtime in
+// runtimeOrder. If no CLI is installed it logs a warning and skips — the UI
+// will surface this through /api/runtimes.
+func autoStartActiveSession() {
+	if sessionStore == nil {
+		log.Printf("autoStartActiveSession: session store not initialised")
+		return
+	}
+	preferred := sessionStore.ActiveRuntime()
+	pick := ""
+	if preferred != "" {
+		if _, err := exec.LookPath(preferred); err == nil {
+			pick = preferred
+		}
+	}
+	if pick == "" {
+		for _, rt := range runtimeOrder {
+			if _, err := exec.LookPath(rt); err == nil {
+				pick = rt
+				break
 			}
 		}
 	}
+	if pick == "" {
+		log.Printf("autoStartActiveSession: no CLI runtime available on PATH; skipping auto-start")
+		return
+	}
+	if pick != preferred {
+		if err := sessionStore.SetActive(pick); err != nil {
+			log.Printf("autoStartActiveSession: persist active=%s: %v", pick, err)
+		}
+	}
+	if _, _, err := getOrCreateSession(pick, defaultPrompt); err != nil {
+		log.Printf("autoStartActiveSession: spawn %s: %v", pick, err)
+		return
+	}
+	log.Printf("autoStartActiveSession: started %s session", pick)
 }
 
 func createPTYSession(runtimeName, prompt string) (*platformPTY, error) {
 	var cmdName string
-	var args []string
 	switch runtimeName {
 	case "copilot":
 		cmdName = "copilot"
@@ -295,11 +336,22 @@ func createPTYSession(runtimeName, prompt string) (*platformPTY, error) {
 		return nil, fmt.Errorf("unknown runtime: %s", runtimeName)
 	}
 
-	// Check if CLI exists
 	if _, err := exec.LookPath(cmdName); err != nil {
 		return nil, fmt.Errorf("%s CLI not found. Please install it first", cmdName)
 	}
 
+	// `--resume <guid>` MUST come first so neither CLI's flag parser confuses
+	// it with the operator prompt that follows. Both copilot and gemini accept
+	// `--resume` together with `-i prompt` (resume restores conversation
+	// history; `-i` injects the operator-level system prompt). Issue #29
+	// confirms this orthogonality.
+	var args []string
+	if sessionStore != nil {
+		guid := sessionStore.GUIDFor(runtimeName)
+		if guid != "" {
+			args = append(args, "--resume", guid)
+		}
+	}
 	if prompt != "" {
 		args = append(args, "-i", prompt)
 	}
@@ -421,18 +473,109 @@ func handleOpFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleRuntimes(w http.ResponseWriter, r *http.Request) {
+	active := ""
+	if sessionStore != nil {
+		active = sessionStore.ActiveRuntime()
+	}
 	runtimes := []map[string]interface{}{}
 	for _, rt := range []struct{ name, cmd string }{
 		{"copilot", "copilot"},
 		{"gemini", "gemini"},
 	} {
 		_, err := exec.LookPath(rt.cmd)
-		runtimes = append(runtimes, map[string]interface{}{
+		entry := map[string]interface{}{
 			"name":      rt.name,
 			"available": err == nil,
-		})
+			"active":    rt.name == active,
+		}
+		if sessionStore != nil {
+			entry["session_id"] = sessionStore.GUIDFor(rt.name)
+		}
+		runtimes = append(runtimes, entry)
 	}
 	json.NewEncoder(w).Encode(runtimes)
+}
+
+// handleRuntimeSwitch atomically tears down the current active PTY and brings
+// up a new one for ?to=<runtime>. Concurrent calls return 409 instead of
+// queueing so the UI can surface the contention as a toast.
+func handleRuntimeSwitch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	to := r.URL.Query().Get("to")
+	if to != "copilot" && to != "gemini" {
+		http.Error(w, "unknown runtime", http.StatusBadRequest)
+		return
+	}
+	if sessionStore == nil {
+		http.Error(w, "session store not initialised", http.StatusInternalServerError)
+		return
+	}
+
+	if !switchMu.TryLock() {
+		http.Error(w, "switch already in progress", http.StatusConflict)
+		return
+	}
+	defer switchMu.Unlock()
+
+	current := sessionStore.ActiveRuntime()
+	if to == current {
+		// No-op: report current state. We still validate that the active PTY
+		// actually exists; if it doesn't, fall through to spawn.
+		sessionsMu.Lock()
+		_, exists := sessions[to]
+		sessionsMu.Unlock()
+		if exists {
+			writeSwitchResponse(w, to, sessionStore.GUIDFor(to))
+			return
+		}
+	}
+
+	if _, err := exec.LookPath(to); err != nil {
+		http.Error(w, fmt.Sprintf("%s CLI not available on PATH", to), http.StatusBadRequest)
+		return
+	}
+
+	// Tear down the currently-active PTY (if any). We snapshot under
+	// sessionsMu but call Terminate / CloseAll outside the lock — Terminate
+	// can block for several seconds and we don't want to block other
+	// session-map readers (e.g. /api/runtimes).
+	sessionsMu.Lock()
+	curSess := sessions[current]
+	curBc := broadcasters[current]
+	delete(sessions, current)
+	delete(broadcasters, current)
+	sessionsMu.Unlock()
+
+	if curSess != nil {
+		curSess.Terminate(3 * time.Second)
+	}
+	if curBc != nil {
+		curBc.CloseAll()
+	}
+
+	if err := sessionStore.SetActive(to); err != nil {
+		log.Printf("handleRuntimeSwitch: persist active=%s: %v", to, err)
+		http.Error(w, "failed to persist new active runtime", http.StatusInternalServerError)
+		return
+	}
+
+	if _, _, err := getOrCreateSession(to, defaultPrompt); err != nil {
+		log.Printf("handleRuntimeSwitch: spawn %s: %v", to, err)
+		http.Error(w, fmt.Sprintf("failed to spawn %s: %v", to, err), http.StatusInternalServerError)
+		return
+	}
+	writeSwitchResponse(w, to, sessionStore.GUIDFor(to))
+}
+
+func writeSwitchResponse(w http.ResponseWriter, runtime, sessionID string) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"active":     runtime,
+		"session_id": sessionID,
+	})
 }
 
 func handleSessionWS(w http.ResponseWriter, r *http.Request) {
@@ -440,6 +583,17 @@ func handleSessionWS(w http.ResponseWriter, r *http.Request) {
 	if rt == "" {
 		rt = "copilot"
 	}
+
+	// Reject WS for non-active runtimes BEFORE upgrading. The frontend must
+	// call POST /api/runtime/switch first; WS never implicitly switches the
+	// active runtime (issue #29 contract).
+	if sessionStore != nil {
+		if active := sessionStore.ActiveRuntime(); active != "" && rt != active {
+			http.Error(w, fmt.Sprintf("runtime %q is not active (active=%q)", rt, active), http.StatusConflict)
+			return
+		}
+	}
+
 	prompt := r.URL.Query().Get("prompt")
 
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -530,11 +684,20 @@ func main() {
 	http.HandleFunc("/api/files", handleOpFiles)
 	http.HandleFunc("/api/file", handleOpFile)
 	http.HandleFunc("/api/runtimes", handleRuntimes)
+	http.HandleFunc("/api/runtime/switch", handleRuntimeSwitch)
 	http.HandleFunc("/ws/session", handleSessionWS)
 
 	// Static files
 	staticFS, _ := fs.Sub(staticFiles, "static")
 	http.Handle("/", http.FileServer(http.FS(staticFS)))
+
+	// Load persistent session-id store before spawning anything that depends
+	// on --resume <guid>.
+	store, err := LoadOrInitStore()
+	if err != nil {
+		log.Fatalf("Failed to load session store: %v", err)
+	}
+	sessionStore = store
 
 	// Start
 	listener, err := net.Listen("tcp", ":"+port)
@@ -545,20 +708,47 @@ func main() {
 	url := fmt.Sprintf("http://localhost:%s", port)
 	fmt.Printf("SWAT Dashboard %s running at %s\n", version, url)
 
-	// Auto-start available CLI sessions
-	autoStartSessions()
+	// Auto-start the single active CLI session (one runtime at a time).
+	autoStartActiveSession()
 
 	openBrowser(url)
 
-	// Graceful shutdown
+	// Graceful shutdown: cleanly terminate the active PTY (and any others
+	// that may have been spawned) before exiting so we don't leave orphaned
+	// CLI processes around.
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
 		fmt.Println("\nShutting down...")
+		shutdownSessions()
 		listener.Close()
 		os.Exit(0)
 	}()
 
 	log.Fatal(http.Serve(listener, nil))
+}
+
+// shutdownSessions terminates every live PTY with a short bounded timeout so
+// we don't leave orphaned CLI processes when the dashboard exits. Safe to
+// call multiple times.
+func shutdownSessions() {
+	sessionsMu.Lock()
+	snapshot := make([]*platformPTY, 0, len(sessions))
+	bcs := make([]*Broadcaster, 0, len(broadcasters))
+	for k, s := range sessions {
+		snapshot = append(snapshot, s)
+		if bc, ok := broadcasters[k]; ok {
+			bcs = append(bcs, bc)
+		}
+		delete(sessions, k)
+		delete(broadcasters, k)
+	}
+	sessionsMu.Unlock()
+	for _, s := range snapshot {
+		s.Terminate(2 * time.Second)
+	}
+	for _, bc := range bcs {
+		bc.CloseAll()
+	}
 }

--- a/pty_unix.go
+++ b/pty_unix.go
@@ -5,6 +5,8 @@ package main
 import (
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
@@ -29,5 +31,34 @@ func (p *platformPTY) Resize(cols, rows int) {
 }
 func (p *platformPTY) Close() {
 	p.ptmx.Close()
-	p.cmd.Process.Kill()
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+}
+
+// Terminate gracefully signals the PTY-attached process and waits up to
+// timeout for it to exit before resorting to SIGKILL. The PTY master is
+// closed last so the broadcaster's Read loop unblocks once the process is
+// gone.
+func (p *platformPTY) Terminate(timeout time.Duration) {
+	proc := p.cmd.Process
+	if proc != nil {
+		_ = proc.Signal(syscall.SIGTERM)
+	}
+	done := make(chan struct{})
+	go func() {
+		if proc != nil {
+			_, _ = proc.Wait()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		if proc != nil {
+			_ = proc.Kill()
+		}
+		<-done
+	}
+	_ = p.ptmx.Close()
 }

--- a/pty_windows.go
+++ b/pty_windows.go
@@ -3,11 +3,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	conpty "github.com/UserExistsError/conpty"
 )
@@ -26,7 +29,6 @@ func quoteArg(a string) string {
 }
 
 func startPTY(cmd *exec.Cmd) (*platformPTY, error) {
-	// Resolve the actual executable path
 	resolved, err := exec.LookPath(cmd.Args[0])
 	if err != nil {
 		resolved = cmd.Args[0]
@@ -37,8 +39,6 @@ func startPTY(cmd *exec.Cmd) (*platformPTY, error) {
 	isBatch := strings.HasSuffix(lower, ".cmd") || strings.HasSuffix(lower, ".bat")
 
 	if isBatch {
-		// .cmd/.bat: run via cmd.exe, but keep stdin alive
-		// Build: cmd.exe /c "full\path\copilot.cmd" -i "prompt" --yolo
 		parts = append(parts, "cmd.exe", "/c")
 		parts = append(parts, quoteArg(resolved))
 		for _, a := range cmd.Args[1:] {
@@ -75,4 +75,21 @@ func (p *platformPTY) Resize(cols, rows int) {
 
 func (p *platformPTY) Close() {
 	p.cpty.Close()
+}
+
+// Terminate force-kills the conpty-attached process tree (taskkill /T /F as a
+// defensive fallback in case ConPty.Close alone leaves orphaned children) and
+// then closes the pty handle. We bound the wait so callers can rely on
+// "Terminate returned -> process is gone (or we tried hard enough)".
+func (p *platformPTY) Terminate(timeout time.Duration) {
+	pid := p.cpty.Pid()
+	if pid != 0 {
+		// Best-effort: kill the whole tree. Errors are intentionally
+		// swallowed because the process may already have exited.
+		_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, _ = p.cpty.Wait(ctx)
+	_ = p.cpty.Close()
 }

--- a/pty_windows.go
+++ b/pty_windows.go
@@ -77,19 +77,38 @@ func (p *platformPTY) Close() {
 	p.cpty.Close()
 }
 
-// Terminate force-kills the conpty-attached process tree (taskkill /T /F as a
-// defensive fallback in case ConPty.Close alone leaves orphaned children) and
-// then closes the pty handle. We bound the wait so callers can rely on
-// "Terminate returned -> process is gone (or we tried hard enough)".
+// Terminate gracefully signals the conpty-attached process tree (taskkill /T,
+// without /F, sends a WM_CLOSE-style request to console processes), waits up
+// to timeout for it to exit, and only then escalates to taskkill /T /F. This
+// mirrors the Unix SIGTERM → wait → SIGKILL pattern so callers get the same
+// "graceful first, then force" contract on both platforms. The pty handle is
+// closed last so the broadcaster's Read loop unblocks once the process is
+// gone.
 func (p *platformPTY) Terminate(timeout time.Duration) {
 	pid := p.cpty.Pid()
 	if pid != 0 {
-		// Best-effort: kill the whole tree. Errors are intentionally
+		// Step 1: graceful tree termination. Errors are intentionally
 		// swallowed because the process may already have exited.
-		_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+		_ = exec.Command("taskkill", "/T", "/PID", strconv.Itoa(pid)).Run()
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_, _ = p.cpty.Wait(ctx)
+	exited := make(chan struct{})
+	go func() {
+		_, _ = p.cpty.Wait(ctx)
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		// Graceful exit (or already dead) within timeout.
+	case <-ctx.Done():
+		// Timed out — escalate to forceful tree kill.
+		if pid != 0 {
+			_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+		}
+		<-exited
+	}
 	_ = p.cpty.Close()
 }

--- a/runtime_switch_test.go
+++ b/runtime_switch_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// setSessionStoreForTest installs a fresh in-memory-backed SessionStore for
+// the duration of a test. It also clears any pre-existing session/broadcaster
+// state so individual handler tests are deterministic.
+func setSessionStoreForTest(t *testing.T, active string) *SessionStore {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("SWAT_DASHBOARD_HOME", dir)
+	s, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("LoadOrInitStore: %v", err)
+	}
+	if active != "" {
+		if err := s.SetActive(active); err != nil {
+			t.Fatalf("SetActive: %v", err)
+		}
+	}
+
+	prevStore := sessionStore
+	sessionStore = s
+	sessionsMu.Lock()
+	prevSessions := sessions
+	prevBcs := broadcasters
+	sessions = make(map[string]*platformPTY)
+	broadcasters = make(map[string]*Broadcaster)
+	sessionsMu.Unlock()
+
+	t.Cleanup(func() {
+		sessionStore = prevStore
+		sessionsMu.Lock()
+		sessions = prevSessions
+		broadcasters = prevBcs
+		sessionsMu.Unlock()
+	})
+	return s
+}
+
+func TestHandleRuntimesIncludesActiveAndSessionID(t *testing.T) {
+	setSessionStoreForTest(t, "gemini")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runtimes", nil)
+	rec := httptest.NewRecorder()
+	handleRuntimes(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{`"name":"copilot"`, `"name":"gemini"`, `"active":true`, `"active":false`, `"session_id"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected body to contain %q; got %s", want, body)
+		}
+	}
+}
+
+func TestHandleRuntimeSwitchInvalidRuntime(t *testing.T) {
+	setSessionStoreForTest(t, "copilot")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/switch?to=bogus", nil)
+	rec := httptest.NewRecorder()
+	handleRuntimeSwitch(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown runtime, got %d", rec.Code)
+	}
+}
+
+func TestHandleRuntimeSwitchRejectsWrongMethod(t *testing.T) {
+	setSessionStoreForTest(t, "copilot")
+	req := httptest.NewRequest(http.MethodGet, "/api/runtime/switch?to=copilot", nil)
+	rec := httptest.NewRecorder()
+	handleRuntimeSwitch(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", rec.Code)
+	}
+}
+
+// TestHandleRuntimeSwitchConcurrentRace exercises the switchMu TryLock path
+// without depending on a real CLI being installed. We hold switchMu from the
+// test body to deterministically force the second request into the 409 branch.
+func TestHandleRuntimeSwitchConcurrentRace(t *testing.T) {
+	setSessionStoreForTest(t, "copilot")
+
+	// Manually take switchMu so any concurrent handler call must observe
+	// TryLock failure → 409. This avoids needing a real CLI on PATH inside
+	// the test runner (which has neither copilot nor gemini installed).
+	switchMu.Lock()
+	defer switchMu.Unlock()
+
+	const n = 4
+	var wg sync.WaitGroup
+	var got409 int32
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/api/runtime/switch?to=gemini", nil)
+			rec := httptest.NewRecorder()
+			handleRuntimeSwitch(rec, req)
+			if rec.Code == http.StatusConflict {
+				atomic.AddInt32(&got409, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	if int(got409) != n {
+		t.Fatalf("expected all %d concurrent calls to receive 409 while switchMu is held, got %d", n, got409)
+	}
+}
+
+func TestHandleSessionWSRejectsInactive(t *testing.T) {
+	setSessionStoreForTest(t, "copilot")
+
+	// Build a request that looks like a WS handshake but to an inactive
+	// runtime; the handler should 409 BEFORE attempting websocket.Upgrade.
+	req := httptest.NewRequest(http.MethodGet, "/ws/session?runtime=gemini", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rec := httptest.NewRecorder()
+	handleSessionWS(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for inactive runtime, got %d", rec.Code)
+	}
+}

--- a/runtime_switch_test.go
+++ b/runtime_switch_test.go
@@ -225,3 +225,64 @@ func TestHandleRuntimeSwitchSetActiveBeforeTeardown(t *testing.T) {
 		t.Fatalf("expected switch handler to return 200, got %d", code)
 	}
 }
+
+// TestGetOrCreateSessionRejectsInactiveRuntime is the regression test for
+// the residual sub-millisecond race window between handleSessionWS's
+// pre-upgrade `rt != active` check (line ~610) and its subsequent
+// getOrCreateSession call (line ~624). A WS connection that has already
+// passed the pre-check can be context-switched out long enough for
+// handleRuntimeSwitch to flip SetActive(to); without a re-check inside
+// getOrCreateSession, the late-arriving handler would resume and spawn a
+// fresh PTY for the now-outgoing runtime, producing an orphan PTY and
+// violating the single-active-runtime invariant.
+//
+// Hardening (PR #30 review id 4190463628 [suggestion]): getOrCreateSession
+// re-checks sessionStore.ActiveRuntime() under sessionsMu and returns an
+// error if the requested runtime is no longer active. This test exercises
+// that gate directly (without going through the WS handshake) so the race
+// window is closed regardless of scheduler timing.
+func TestGetOrCreateSessionRejectsInactiveRuntime(t *testing.T) {
+	setSessionStoreForTest(t, "gemini")
+
+	// Calling getOrCreateSession with a runtime that is not currently
+	// active must be rejected with a "not active" error and must NOT
+	// insert any entry into the sessions map.
+	if _, _, err := getOrCreateSession("copilot", ""); err == nil {
+		t.Fatal("expected getOrCreateSession to reject inactive runtime, got nil error")
+	} else if !strings.Contains(err.Error(), "not active") {
+		t.Fatalf("expected error to mention \"not active\", got %v", err)
+	}
+
+	sessionsMu.Lock()
+	_, leaked := sessions["copilot"]
+	_, bcLeaked := broadcasters["copilot"]
+	sessionsMu.Unlock()
+	if leaked || bcLeaked {
+		t.Fatal("inactive runtime must not be inserted into sessions/broadcasters maps (orphan-PTY guard regressed)")
+	}
+
+	// The gate must NOT block lookups for an already-spawned active
+	// runtime — handleRuntimeSwitch's spawnSessionFn and the subscribe
+	// path both rely on this. Pre-seed an active session and confirm the
+	// existing-entry fast path returns it without touching createPTYSession.
+	seedPTY := &platformPTY{}
+	seedBc := NewBroadcaster()
+	sessionsMu.Lock()
+	sessions["gemini"] = seedPTY
+	broadcasters["gemini"] = seedBc
+	sessionsMu.Unlock()
+	t.Cleanup(func() {
+		sessionsMu.Lock()
+		delete(sessions, "gemini")
+		delete(broadcasters, "gemini")
+		sessionsMu.Unlock()
+	})
+
+	sess, bc, err := getOrCreateSession("gemini", "")
+	if err != nil {
+		t.Fatalf("getOrCreateSession for active runtime returned error: %v", err)
+	}
+	if sess != seedPTY || bc != seedBc {
+		t.Fatal("expected pre-seeded active session/broadcaster to be returned unchanged")
+	}
+}

--- a/runtime_switch_test.go
+++ b/runtime_switch_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // setSessionStoreForTest installs a fresh in-memory-backed SessionStore for
@@ -130,5 +131,97 @@ func TestHandleSessionWSRejectsInactive(t *testing.T) {
 	handleSessionWS(rec, req)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("expected 409 for inactive runtime, got %d", rec.Code)
+	}
+}
+
+// TestHandleRuntimeSwitchSetActiveBeforeTeardown is the regression test for
+// the orphan-PTY race: SetActive(to) MUST be persisted BEFORE the outgoing
+// PTY teardown so that any WS upgrade for the OLD runtime arriving during
+// the multi-second teardown window is rejected by handleSessionWS's
+// pre-upgrade `rt != active` check (issue from PR #30 review).
+//
+// The test stubs lookPathFn / spawnSessionFn (so we don't need a real CLI on
+// PATH) and stubs terminatePTYFn with a slow function. While teardown is
+// blocked inside terminatePTYFn, we fire a WS upgrade for the OUTGOING
+// runtime and assert it gets 409. With the pre-fix code (SetActive AFTER
+// teardown), ActiveRuntime() would still report `copilot` during teardown
+// and the WS upgrade would proceed → orphan PTY.
+func TestHandleRuntimeSwitchSetActiveBeforeTeardown(t *testing.T) {
+	setSessionStoreForTest(t, "copilot")
+
+	// Stub LookPath / spawn so the handler doesn't need real CLIs on PATH.
+	prevLookPath := lookPathFn
+	prevSpawn := spawnSessionFn
+	prevTerminate := terminatePTYFn
+	t.Cleanup(func() {
+		lookPathFn = prevLookPath
+		spawnSessionFn = prevSpawn
+		terminatePTYFn = prevTerminate
+	})
+	lookPathFn = func(string) (string, error) { return "/stub/path", nil }
+	spawnSessionFn = func(string) error { return nil }
+
+	// Inject a fake current PTY so the teardown branch is exercised. We
+	// never call a real method on it because terminatePTYFn is stubbed.
+	sessionsMu.Lock()
+	sessions["copilot"] = &platformPTY{}
+	sessionsMu.Unlock()
+
+	// Coordination: terminatePTYFn blocks until we close `release`. We
+	// observe ActiveRuntime() inside terminatePTYFn AND fire a concurrent
+	// WS request for the outgoing runtime to assert pre-upgrade rejection.
+	teardownEntered := make(chan struct{})
+	release := make(chan struct{})
+	var observedActive string
+	terminatePTYFn = func(p *platformPTY, d time.Duration) {
+		observedActive = sessionStore.ActiveRuntime()
+		close(teardownEntered)
+		<-release
+	}
+
+	switchDone := make(chan int, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/runtime/switch?to=gemini", nil)
+		rec := httptest.NewRecorder()
+		handleRuntimeSwitch(rec, req)
+		switchDone <- rec.Code
+	}()
+
+	// Wait for the switch handler to enter teardown.
+	select {
+	case <-teardownEntered:
+	case <-time.After(2 * time.Second):
+		close(release)
+		<-switchDone
+		t.Fatal("switch handler did not reach teardown within 2s")
+	}
+
+	// At this point SetActive must have already flipped to "gemini".
+	if observedActive != "gemini" {
+		close(release)
+		<-switchDone
+		t.Fatalf("expected ActiveRuntime()==\"gemini\" at teardown entry; got %q (SetActive ran AFTER teardown — race fix regressed)", observedActive)
+	}
+
+	// While teardown is still in flight, a WS upgrade for the OUTGOING
+	// runtime ("copilot") must be rejected by handleSessionWS's pre-upgrade
+	// gate, proving no orphan PTY can be respawned for the old runtime.
+	wsReq := httptest.NewRequest(http.MethodGet, "/ws/session?runtime=copilot", nil)
+	wsReq.Header.Set("Connection", "Upgrade")
+	wsReq.Header.Set("Upgrade", "websocket")
+	wsReq.Header.Set("Sec-WebSocket-Version", "13")
+	wsReq.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	wsRec := httptest.NewRecorder()
+	handleSessionWS(wsRec, wsReq)
+	if wsRec.Code != http.StatusConflict {
+		close(release)
+		<-switchDone
+		t.Fatalf("expected 409 for WS upgrade against outgoing runtime mid-switch, got %d (orphan-PTY race window still open)", wsRec.Code)
+	}
+
+	// Allow teardown to finish and switch handler to complete.
+	close(release)
+	if code := <-switchDone; code != http.StatusOK {
+		t.Fatalf("expected switch handler to return 200, got %d", code)
 	}
 }

--- a/sessions_store.go
+++ b/sessions_store.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionStore tracks the persistent per-runtime resume session ids and the
+// currently-active runtime. It is persisted to ~/.swat-dashboard/sessions.json
+// (or $SWAT_DASHBOARD_HOME/sessions.json in tests) using an atomic
+// write-tmp + rename so a crash mid-write cannot brick the dashboard.
+type SessionStore struct {
+	mu       sync.RWMutex
+	path     string
+	Active   string            `json:"active"`
+	Sessions map[string]string `json:"sessions"`
+}
+
+// sessionStoreDir returns the directory holding sessions.json. SWAT_DASHBOARD_HOME
+// overrides the default for tests.
+func sessionStoreDir() (string, error) {
+	if v := os.Getenv("SWAT_DASHBOARD_HOME"); v != "" {
+		return v, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home dir: %w", err)
+	}
+	return filepath.Join(home, ".swat-dashboard"), nil
+}
+
+// LoadOrInitStore reads sessions.json from the standard location, creating it
+// if missing and recovering from JSON corruption by backing up the broken file
+// and rebuilding a fresh one.
+func LoadOrInitStore() (*SessionStore, error) {
+	dir, err := sessionStoreDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	return loadOrInitStoreAt(filepath.Join(dir, "sessions.json"))
+}
+
+// loadOrInitStoreAt is the testable core of LoadOrInitStore.
+func loadOrInitStoreAt(path string) (*SessionStore, error) {
+	s := &SessionStore{
+		path:     path,
+		Active:   "copilot",
+		Sessions: map[string]string{},
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := s.persistLocked(); err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+	var raw struct {
+		Active   string            `json:"active"`
+		Sessions map[string]string `json:"sessions"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// Corrupt → back up and rebuild.
+		bak := fmt.Sprintf("%s.bak.%d", path, time.Now().Unix())
+		if rerr := os.Rename(path, bak); rerr != nil {
+			_ = os.WriteFile(bak, data, 0o600)
+		}
+		if perr := s.persistLocked(); perr != nil {
+			return nil, perr
+		}
+		return s, nil
+	}
+	if raw.Active != "" {
+		s.Active = raw.Active
+	}
+	if raw.Sessions != nil {
+		s.Sessions = raw.Sessions
+	}
+	return s, nil
+}
+
+// GUIDFor returns a stable UUID v4 for runtime, generating and persisting a
+// new one if the existing entry is missing or not a valid UUID v4.
+func (s *SessionStore) GUIDFor(runtime string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cur, ok := s.Sessions[runtime]; ok && isValidUUIDv4(cur) {
+		return cur
+	}
+	id := uuid.NewString()
+	if s.Sessions == nil {
+		s.Sessions = map[string]string{}
+	}
+	s.Sessions[runtime] = id
+	_ = s.persistLocked()
+	return id
+}
+
+// SetActive persists active runtime atomically.
+func (s *SessionStore) SetActive(runtime string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Active = runtime
+	return s.persistLocked()
+}
+
+// ActiveRuntime returns the currently-active runtime name (snapshot).
+func (s *SessionStore) ActiveRuntime() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Active
+}
+
+// Snapshot returns a copy of the (active, sessions) state.
+func (s *SessionStore) Snapshot() (string, map[string]string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := make(map[string]string, len(s.Sessions))
+	for k, v := range s.Sessions {
+		cp[k] = v
+	}
+	return s.Active, cp
+}
+
+// persistLocked writes the store atomically. Caller must hold s.mu.
+func (s *SessionStore) persistLocked() error {
+	if s.path == "" {
+		return fmt.Errorf("session store has no backing path")
+	}
+	payload := struct {
+		Active   string            `json:"active"`
+		Sessions map[string]string `json:"sessions"`
+	}{Active: s.Active, Sessions: s.Sessions}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal session store: %w", err)
+	}
+	dir := filepath.Dir(s.path)
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return fmt.Errorf("rand suffix: %w", err)
+	}
+	tmp := filepath.Join(dir, fmt.Sprintf("sessions.json.tmp.%s", hex.EncodeToString(suffix)))
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename tmp -> %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// isValidUUIDv4 reports whether s parses as a UUID and is variant RFC 4122
+// version 4. Other versions and the nil UUID are rejected so callers
+// regenerate a fresh v4 — matching the issue #29 contract.
+func isValidUUIDv4(s string) bool {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return false
+	}
+	if id.Version() != 4 {
+		return false
+	}
+	if id.Variant() != uuid.RFC4122 {
+		return false
+	}
+	return true
+}

--- a/sessions_store_test.go
+++ b/sessions_store_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// helper: isolate a SessionStore inside a per-test temp dir.
+func newStoreInTemp(t *testing.T) (*SessionStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("SWAT_DASHBOARD_HOME", dir)
+	s, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("LoadOrInitStore: %v", err)
+	}
+	return s, filepath.Join(dir, "sessions.json")
+}
+
+func TestSessionStoreRoundTrip(t *testing.T) {
+	s, path := newStoreInTemp(t)
+
+	if s.ActiveRuntime() != "copilot" {
+		t.Fatalf("expected default active=copilot, got %q", s.ActiveRuntime())
+	}
+
+	g1 := s.GUIDFor("copilot")
+	g2 := s.GUIDFor("gemini")
+	if g1 == "" || g2 == "" || g1 == g2 {
+		t.Fatalf("expected two distinct guids, got %q %q", g1, g2)
+	}
+	if !isValidUUIDv4(g1) || !isValidUUIDv4(g2) {
+		t.Fatalf("guids must be UUIDv4: %q %q", g1, g2)
+	}
+	if err := s.SetActive("gemini"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+
+	// Reload from disk and verify state survives.
+	s2, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if s2.ActiveRuntime() != "gemini" {
+		t.Fatalf("expected reloaded active=gemini, got %q", s2.ActiveRuntime())
+	}
+	if got := s2.GUIDFor("copilot"); got != g1 {
+		t.Fatalf("expected reloaded copilot guid %q, got %q", g1, got)
+	}
+	if got := s2.GUIDFor("gemini"); got != g2 {
+		t.Fatalf("expected reloaded gemini guid %q, got %q", g2, got)
+	}
+
+	// Sanity: file actually exists and is valid JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var raw struct {
+		Active   string            `json:"active"`
+		Sessions map[string]string `json:"sessions"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("on-disk JSON invalid: %v", err)
+	}
+}
+
+func TestSessionStoreCorruptionRecovery(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SWAT_DASHBOARD_HOME", dir)
+	path := filepath.Join(dir, "sessions.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("LoadOrInitStore: %v", err)
+	}
+	if s.ActiveRuntime() != "copilot" {
+		t.Fatalf("expected default active after recovery, got %q", s.ActiveRuntime())
+	}
+	// Backup file should exist.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	bakFound := false
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "sessions.json.bak.") {
+			bakFound = true
+		}
+	}
+	if !bakFound {
+		t.Fatalf("expected sessions.json.bak.<ts>, got entries: %v", entries)
+	}
+	// Rebuilt file is valid.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rebuilt: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("rebuilt file is not valid JSON: %v", err)
+	}
+}
+
+func TestSessionStoreInvalidUUID(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SWAT_DASHBOARD_HOME", dir)
+	path := filepath.Join(dir, "sessions.json")
+
+	good := "550e8400-e29b-41d4-a716-446655440000"
+	seed := map[string]any{
+		"active": "copilot",
+		"sessions": map[string]string{
+			"copilot": "not-a-uuid",
+			"gemini":  good,
+		},
+	}
+	data, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("LoadOrInitStore: %v", err)
+	}
+	g := s.GUIDFor("copilot")
+	if g == "not-a-uuid" {
+		t.Fatalf("expected regenerated UUID for invalid copilot entry, still got %q", g)
+	}
+	if !isValidUUIDv4(g) {
+		t.Fatalf("regenerated id %q is not a valid UUIDv4", g)
+	}
+	// Gemini's valid id must be preserved.
+	if got := s.GUIDFor("gemini"); got != good {
+		t.Fatalf("expected gemini guid preserved, got %q", got)
+	}
+}
+
+func TestSessionStoreAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SWAT_DASHBOARD_HOME", dir)
+	s, err := LoadOrInitStore()
+	if err != nil {
+		t.Fatalf("LoadOrInitStore: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		_ = s.GUIDFor("copilot")
+		if err := s.SetActive("gemini"); err != nil {
+			t.Fatalf("SetActive: %v", err)
+		}
+		if err := s.SetActive("copilot"); err != nil {
+			t.Fatalf("SetActive: %v", err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Fatalf("found leftover temp file %q — atomic write must clean up", e.Name())
+		}
+	}
+}
+
+func TestSessionStoreConcurrentGUIDFor(t *testing.T) {
+	// Concurrent GUIDFor calls for the same runtime must agree on a single
+	// stable id (no race-induced second regeneration).
+	s, _ := newStoreInTemp(t)
+	const n = 32
+	results := make([]string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			results[i] = s.GUIDFor("copilot")
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < n; i++ {
+		if results[i] != results[0] {
+			t.Fatalf("concurrent GUIDFor returned divergent ids: %q vs %q", results[0], results[i])
+		}
+	}
+}

--- a/static/app.js
+++ b/static/app.js
@@ -139,8 +139,22 @@ function teardownRuntimeState(rt) {
   if (state.ws) { state.ws.onclose = null; try { state.ws.close(); } catch(e) {} state.ws = null; }
 }
 
+let switchInFlight = false;
 async function switchRuntime(to) {
+  if (switchInFlight) return;
   if (to === currentRuntime) return;
+  switchInFlight = true;
+  // Disable BOTH runtime tab buttons during the in-flight window so a
+  // double-click cannot race the backend into an unnecessary 409. We
+  // restore visual state in finally; on the success path loadRuntimes
+  // re-renders tabs from scratch which also clears the disabled styles.
+  const tabs = document.querySelectorAll('#runtime-tabs .tab');
+  tabs.forEach(t => {
+    t.dataset.prevPointer = t.style.pointerEvents;
+    t.dataset.prevOpacity = t.style.opacity;
+    t.style.pointerEvents = 'none';
+    t.style.opacity = '0.5';
+  });
   try {
     const resp = await fetch('/api/runtime/switch?to=' + encodeURIComponent(to), { method:'POST' });
     if (resp.status === 200) {
@@ -160,6 +174,18 @@ async function switchRuntime(to) {
     }
   } catch (e) {
     toast('Switch failed: ' + e.message, 'error');
+  } finally {
+    switchInFlight = false;
+    // Restore tabs that survived the in-flight window. On success/409/400
+    // loadRuntimes re-renders tabs entirely (these resets are no-ops on the
+    // freshly-rendered DOM); on the unexpected error/catch paths this
+    // restores the original interactive state.
+    document.querySelectorAll('#runtime-tabs .tab').forEach(t => {
+      t.style.pointerEvents = t.dataset.prevPointer || '';
+      t.style.opacity = t.dataset.prevOpacity || '';
+      delete t.dataset.prevPointer;
+      delete t.dataset.prevOpacity;
+    });
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -69,8 +69,9 @@ function initTerminal() {
   ro.observe(document.getElementById('terminal-container'));
 }
 
-function connectSession() {
-  const rt = document.getElementById('runtime-select').value;
+function connectSession(rt) {
+  if (!rt) rt = currentRuntime;
+  if (!rt) return;
   // Hide all terminal divs
   for (const s of Object.values(terminals)) s.div.style.display = 'none';
   const state = getOrCreateTerminal(rt);
@@ -112,11 +113,73 @@ function connectSession() {
   };
 }
 
-document.getElementById('runtime-select').addEventListener('change', () => {
-  if (document.getElementById('terminal-inner').style.display !== 'none') {
-    connectSession();
+// Toast helper for switch feedback
+function toast(msg, kind) {
+  let el = document.getElementById('runtime-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'runtime-toast';
+    el.style.cssText = 'position:fixed;bottom:20px;right:20px;padding:10px 16px;border-radius:6px;font-size:13px;z-index:9999;box-shadow:0 4px 12px rgba(0,0,0,0.3);max-width:360px;';
+    document.body.appendChild(el);
   }
-});
+  el.style.background = kind === 'error' ? '#c0392b' : '#34495e';
+  el.style.color = '#fff';
+  el.textContent = msg;
+  el.style.display = 'block';
+  clearTimeout(el._t);
+  el._t = setTimeout(() => { el.style.display = 'none'; }, 4000);
+}
+
+// Tear down a runtime's local WS+terminal state so a follow-up
+// connectSession() spins up a fresh one against the new active backend.
+function teardownRuntimeState(rt) {
+  const state = terminals[rt];
+  if (!state) return;
+  if (state.closeTimer) { clearTimeout(state.closeTimer); state.closeTimer = null; }
+  if (state.ws) { state.ws.onclose = null; try { state.ws.close(); } catch(e) {} state.ws = null; }
+}
+
+async function switchRuntime(to) {
+  if (to === currentRuntime) return;
+  try {
+    const resp = await fetch('/api/runtime/switch?to=' + encodeURIComponent(to), { method:'POST' });
+    if (resp.status === 200) {
+      teardownRuntimeState(currentRuntime);
+      teardownRuntimeState(to);
+      await loadRuntimes(true);
+      connectSession(to);
+    } else if (resp.status === 409) {
+      toast('Another runtime switch is in progress. Try again.', 'error');
+      loadRuntimes(true);
+    } else if (resp.status === 400) {
+      toast(to + ' CLI is not available on PATH', 'error');
+      loadRuntimes(true);
+    } else {
+      const txt = await resp.text();
+      toast('Switch failed: ' + (txt || resp.statusText), 'error');
+    }
+  } catch (e) {
+    toast('Switch failed: ' + e.message, 'error');
+  }
+}
+
+function renderRuntimeTabs(runtimes, activeName) {
+  const container = document.getElementById('runtime-tabs');
+  if (!container) return;
+  container.innerHTML = '';
+  runtimes.forEach(rt => {
+    const tab = document.createElement('div');
+    const isActive = rt.name === activeName;
+    tab.className = 'tab' + (isActive ? ' active' : '');
+    tab.textContent = rt.name + (rt.available ? '' : ' (n/a)');
+    tab.title = rt.session_id ? ('session ' + rt.session_id) : '';
+    tab.style.cssText = 'cursor:' + (rt.available ? 'pointer' : 'not-allowed') + ';opacity:' + (rt.available ? '1' : '0.5') + ';padding:4px 12px;border-radius:6px;font-size:12px;border:1px solid var(--border);' + (isActive ? 'background:var(--accent);color:#fff;border-color:var(--accent);' : 'background:var(--bg);color:var(--fg);');
+    if (rt.available) {
+      tab.addEventListener('click', () => switchRuntime(rt.name));
+    }
+    container.appendChild(tab);
+  });
+}
 
 // --- Tabs ---
 function showTab(name) {
@@ -518,24 +581,17 @@ loadRuntimes();
 setInterval(loadActiveOps, 5000);
 setInterval(loadStats, 10000);
 
-async function loadRuntimes() {
+async function loadRuntimes(skipAutoConnect) {
   try {
     const resp = await fetch('/api/runtimes');
     const runtimes = await resp.json();
-    const select = document.getElementById('runtime-select');
-    select.innerHTML = '';
-    runtimes.forEach(rt => {
-      const opt = document.createElement('option');
-      opt.value = rt.name;
-      opt.textContent = rt.name + (rt.available ? '' : ' (not installed)');
-      opt.disabled = !rt.available;
-      select.appendChild(opt);
-    });
-    // Select first available and auto-connect
-    const first = runtimes.find(r => r.available);
-    if (first) {
-      select.value = first.name;
-      connectSession();
+    const active = (runtimes.find(r => r.active) || {}).name || '';
+    renderRuntimeTabs(runtimes, active);
+    if (skipAutoConnect) return;
+    const target = runtimes.find(r => r.active && r.available)
+                || runtimes.find(r => r.available);
+    if (target) {
+      connectSession(target.name);
     } else {
       document.getElementById('terminal-placeholder').innerHTML = '<div style="color:var(--fg2);font-size:14px;">No CLI runtimes installed</div>';
     }

--- a/static/index.html
+++ b/static/index.html
@@ -46,10 +46,7 @@
     <div class="right-header">
       <div class="tab active" id="tab-session" onclick="showTab('session')">Session</div>
       <div class="tab" id="tab-detail" onclick="showTab('detail')">Detail</div>
-      <select id="runtime-select" style="margin-left:auto;background:var(--bg);border:1px solid var(--border);color:var(--fg);border-radius:6px;padding:4px 8px;font-size:12px;">
-        <option value="copilot">Copilot CLI</option>
-        <option value="gemini">Gemini CLI</option>
-      </select>
+      <div id="runtime-tabs" style="margin-left:auto;display:flex;gap:4px;"></div>
     </div>
     <div class="right-content">
       <div id="terminal-container" class="visible">


### PR DESCRIPTION
# Single-active runtime ownership with persistent `--resume` sessions

Closes #29.

## What

Establishes the dashboard backend as the single authority over which CLI runtime is "active" at any moment, and gives every runtime a persistent UUID v4 that is injected as `--resume <guid>` so sessions survive process restarts, dashboard restarts, and runtime switches.

## Why

Today both copilot and gemini are auto-spawned at boot, racing for the same on-disk session state and corrupting each other. Switching runtimes from the UI never tears the previous PTY down. Issue #29 calls this out as the root cause of "ops disappear on switch" reports.

## Changes

### Backend
- **`sessions_store.go`** — new `SessionStore` persists `~/.swat-dashboard/sessions.json` (override via `SWAT_DASHBOARD_HOME`). Atomic writes (tmp + rename), UUID v4 validation (rejects v1/v3/v5/nil/non-RFC4122), corruption recovery (renames bad file to `.bak.<unix-ts>` and rebuilds defaults).
- **`main.go`**
  - `autoStartActiveSession()` replaces `autoStartSessions()`: prefers persisted active runtime, falls back to first available, persists fallback if it differs from preference.
  - `createPTYSession()` prepends `--resume <guid>` from `sessionStore.GUIDFor(runtime)` to every CLI invocation.
  - `POST /api/runtime/switch?to=<runtime>`: `switchMu.TryLock()` → 409 on contention, 400 on unknown runtime, 405 on wrong method, no-op on `to == active`. Tears down the active PTY with `Terminate(3s)` + `bc.CloseAll()`, persists new active, spawns the new PTY.
  - `GET /api/runtimes` now includes `active` (bool) and `session_id` (uuid) fields.
  - `handleSessionWS` rejects non-active runtimes with **HTTP 409 *before* upgrade** (frontend must call `/api/runtime/switch` first; WS never implicitly switches active).
  - `shutdownSessions()` on SIGINT/SIGTERM iterates live PTYs and calls `Terminate(2s)` so we don't leave orphaned CLI processes.
- **`pty_unix.go`** / **`pty_windows.go`** — added `Terminate(timeout time.Duration)`. Unix: SIGTERM → bounded `Wait` → force `Kill` on timeout → `ptmx.Close`. Windows: `taskkill /T /F /PID <cpty.Pid()>` → context-bounded `cpty.Wait` → `cpty.Close`.
- **`broadcast.go`** — `onExit` wrapped in `sync.Once` so the switch path's explicit teardown and the EOF-driven path are idempotent. New `CloseAll()` drains every subscriber.

### Frontend
- **`static/index.html`** — `<select id="runtime-select">` replaced with `<div id="runtime-tabs">` container.
- **`static/app.js`**
  - Tabs render from `/api/runtimes` using new `active` + `session_id` fields. Active tab is highlighted; unavailable runtimes are dim and unclickable; tab `title` shows session UUID.
  - Click → `switchRuntime(to)` POSTs `/api/runtime/switch?to=<rt>`:
    - **200** → tear down local WS state, refresh runtimes, reconnect to new active.
    - **409** → toast "another runtime switch is in progress".
    - **400** → toast "<rt> CLI is not available on PATH".
  - `connectSession(rt)` now takes an explicit runtime argument (the select is gone).

### Tests
- **`sessions_store_test.go`** — 5 unit tests: round trip, corruption recovery (verifies `.bak.<ts>` + rebuild), invalid UUID regeneration (per-entry, not whole file), atomic write (no leftover `.tmp.*` after success), concurrent `GUIDFor`.
- **`runtime_switch_test.go`** — 5 handler tests: `/api/runtimes` shape includes `active`+`session_id`, `/api/runtime/switch` 405 on wrong method, 400 on unknown runtime, deterministic 409 on `switchMu` contention (test holds the mutex), WS 409 on inactive runtime.

## How to Test

```bash
go build ./...
go vet ./...
go test ./...
GOOS=linux go build ./...
node --check static/app.js
```

All green locally on Windows go1.24.1, including `GOOS=linux` cross-build.

Manual:
1. Start dashboard with neither runtime in `sessions.json` → exactly one CLI spawns (the persisted active or first available).
2. Restart dashboard → same `--resume <guid>` flag is passed → session continuity preserved.
3. Click the inactive runtime tab → previous PTY is killed within 3s, new one starts. Tabs swap highlight.
4. Click both tabs in rapid succession → one toast "switch in progress" appears.
5. Quit the dashboard with Ctrl+C → no orphan `copilot`/`gemini` processes remain.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
