### PR TITLE
feat: operation status & card UX redesign (failure_reason buckets + visual hierarchy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,21 @@ The SWAT Dashboard features a Go backend with embedded static files. It serves a
 - **Backend:** Go, `gorilla/websocket`, `creack/pty`, `conpty`
 - **Frontend:** xterm.js
 - **Integration:** `swat/commander/operation`
+
+## Design System
+
+This project follows **GitHub Primer Dark** as the design contract. All colors must use the CSS custom properties defined in `static/style.css` (e.g. `--color-canvas-default`, `--color-fg-default`, `--color-accent-fg`). **No ad-hoc hex color literals** — future contributors must use the established tokens.
+
+Key tokens:
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-canvas-default` | `#0d1117` | Page background |
+| `--color-fg-default` | `#e6edf3` | Primary text |
+| `--color-fg-muted` | `#7d8590` | Secondary text |
+| `--color-accent-fg` | `#58a6ff` | Links, accent |
+| `--color-success-fg` | `#3fb950` | Active/success |
+| `--color-danger-fg` | `#f85149` | Errors, crashed |
+| `--color-attention-fg` | `#d29922` | Warnings, setup |
+| `--color-done-fg` | `#a371f7` | Config needed |
+
+Monospace font stack: `'SF Mono', 'JetBrains Mono', 'Cascadia Code', Consolas, ui-monospace, monospace`

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 )
 
 require (
-	github.com/LangSensei/swat v1.2.0
+	github.com/LangSensei/swat v1.2.2
 	github.com/UserExistsError/conpty v0.1.4
 	golang.org/x/sys v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LangSensei/swat v1.2.0 h1:C9BAPXksK+zzsL8jalqm/4inJD9A4FjmyuLI3thThs4=
-github.com/LangSensei/swat v1.2.0/go.mod h1:nRyrxrqnujB0vzgSYvOmwjgTJjmAf7/QNVodSOOUBFw=
+github.com/LangSensei/swat v1.2.2 h1:C5icPw+7cTVDC3wtwhaK12ZXtR5nthTI4d9bZ5bFuro=
+github.com/LangSensei/swat v1.2.2/go.mod h1:nRyrxrqnujB0vzgSYvOmwjgTJjmAf7/QNVodSOOUBFw=
 github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
 github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/main.go
+++ b/main.go
@@ -38,14 +38,15 @@ var upgrader = websocket.Upgrader{
 
 // OpView is a lightweight UI view of an operation
 type OpView struct {
-	ID          string `json:"id"`
-	Squad       string `json:"squad"`
-	Status      string `json:"status"`
-	Brief       string `json:"brief"`
-	Summary     string `json:"summary"`
-	CreatedAt   string `json:"created_at"`
-	CompletedAt string `json:"completed_at,omitempty"`
-	Elapsed     string `json:"elapsed,omitempty"`
+	ID            string `json:"id"`
+	Squad         string `json:"squad"`
+	Status        string `json:"status"`
+	Brief         string `json:"brief"`
+	Summary       string `json:"summary"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	CompletedAt   string `json:"completed_at,omitempty"`
+	Elapsed       string `json:"elapsed,omitempty"`
 }
 
 func opToView(op *operation.Operation) OpView {
@@ -55,6 +56,9 @@ func opToView(op *operation.Operation) OpView {
 		Status:  op.Status,
 		Brief:   op.Brief,
 		Summary: op.Summary,
+	}
+	if op.FailureReason != nil {
+		v.FailureReason = *op.FailureReason
 	}
 	if !op.CreatedAt.IsZero() {
 		v.CreatedAt = op.CreatedAt.Format(time.RFC3339)
@@ -401,12 +405,27 @@ func homeDir() string {
 
 // --- HTTP Handlers ---
 
-// handleStats returns operation counts by status.
+// handleStats returns operation counts by status and failure_reason buckets.
 func handleStats(w http.ResponseWriter, r *http.Request) {
 	all, _ := operation.List()
-	counts := map[string]int{"active": 0, "queued": 0, "completed": 0, "failed": 0}
+	counts := map[string]int{
+		"active": 0, "queued": 0, "completed": 0, "failed": 0,
+		"cancelled": 0, "crashed": 0, "setup": 0, "config": 0,
+	}
 	for _, op := range all {
 		counts[op.Status]++
+		if op.Status == "failed" && op.FailureReason != nil {
+			switch *op.FailureReason {
+			case "cancelled_by_user":
+				counts["cancelled"]++
+			case "process_exited_without_completion":
+				counts["crashed"]++
+			case "classify_spawn_failed", "classify_move_failed", "provision_failed", "launch_failed":
+				counts["setup"]++
+			case "classify_no_squad", "classify_squad_not_installed":
+				counts["config"]++
+			}
+		}
 	}
 	json.NewEncoder(w).Encode(counts)
 }

--- a/static/app.js
+++ b/static/app.js
@@ -25,8 +25,8 @@ function getOrCreateTerminal(rt) {
   container.appendChild(div);
   const t = new Terminal({
     scrollback: 10000,
-    theme: { background:'#0d1117', foreground:'#c9d1d9', cursor:'#58a6ff', selectionBackground:'#264f78' },
-    fontFamily: "'Cascadia Code','Fira Code',monospace",
+    theme: { background:'#0d1117', foreground:'#e6edf3', cursor:'#58a6ff', selectionBackground:'#264f78' },
+    fontFamily: "var(--font-mono, 'Cascadia Code','Fira Code',monospace)",
     fontSize: 14,
     cursorBlink: true
   });
@@ -106,7 +106,7 @@ function connectSession(rt) {
     state.closeTimer = setTimeout(() => {
       if ((!state.ws || state.ws.readyState !== WebSocket.OPEN) && currentRuntime === rt) {
         state.div.style.display = 'none';
-        document.getElementById('terminal-placeholder').innerHTML = '<div style="color:var(--fg2);font-size:14px;">Disconnected</div><button onclick="connectSession()" style="background:var(--accent);border:none;color:#fff;padding:8px 20px;border-radius:6px;cursor:pointer;font-size:13px;">Reconnect</button>';
+        document.getElementById('terminal-placeholder').innerHTML = '<div style="color:var(--color-fg-muted);font-size:14px;">Disconnected</div><button onclick="connectSession()" style="background:var(--color-accent-fg);border:none;color:#fff;padding:8px 20px;border-radius:6px;cursor:pointer;font-size:13px;">Reconnect</button>';
         document.getElementById('terminal-placeholder').style.display = 'flex';
       }
     }, 2000);
@@ -122,8 +122,8 @@ function toast(msg, kind) {
     el.style.cssText = 'position:fixed;bottom:20px;right:20px;padding:10px 16px;border-radius:6px;font-size:13px;z-index:9999;box-shadow:0 4px 12px rgba(0,0,0,0.3);max-width:360px;';
     document.body.appendChild(el);
   }
-  el.style.background = kind === 'error' ? '#c0392b' : '#34495e';
-  el.style.color = '#fff';
+  el.style.background = kind === 'error' ? 'var(--color-danger-fg)' : 'var(--color-canvas-subtle)';
+  el.style.color = 'var(--color-fg-default)';
   el.textContent = msg;
   el.style.display = 'block';
   clearTimeout(el._t);
@@ -199,7 +199,7 @@ function renderRuntimeTabs(runtimes, activeName) {
     tab.className = 'tab' + (isActive ? ' active' : '');
     tab.textContent = rt.name + (rt.available ? '' : ' (n/a)');
     tab.title = rt.session_id ? ('session ' + rt.session_id) : '';
-    tab.style.cssText = 'cursor:' + (rt.available ? 'pointer' : 'not-allowed') + ';opacity:' + (rt.available ? '1' : '0.5') + ';padding:4px 12px;border-radius:6px;font-size:12px;border:1px solid var(--border);' + (isActive ? 'background:var(--accent);color:#fff;border-color:var(--accent);' : 'background:var(--bg);color:var(--fg);');
+    tab.style.cssText = 'cursor:' + (rt.available ? 'pointer' : 'not-allowed') + ';opacity:' + (rt.available ? '1' : '0.5') + ';padding:4px 12px;border-radius:6px;font-size:12px;border:1px solid var(--color-border-default);' + (isActive ? 'background:var(--color-accent-fg);color:#fff;border-color:var(--color-accent-fg);' : 'background:var(--color-canvas-default);color:var(--color-fg-default);');
     if (rt.available) {
       tab.addEventListener('click', () => switchRuntime(rt.name));
     }
@@ -220,19 +220,128 @@ function showTab(name) {
 }
 
 // --- Operations ---
+
+// Brief sanitizer: strip routing noise to keep semantic content.
+function sanitizeBrief(text) {
+  if (!text) return '';
+  return text
+    .replace(/^\[.*?\]\s*/g, '')        // [squad-prefix]
+    .replace(/^Branch:\s*\S+\s*/gi, '') // Branch: xxx
+    .replace(/^Mode\s+\w+\s*/gi, '')    // Mode X
+    .replace(/^###\s*Context\s*/gi, '') // ### Context heading
+    .trim();
+}
+
+// Relative time: "3 min ago", "2h ago", "just now"
+function relativeTime(isoStr) {
+  if (!isoStr) return '';
+  const d = new Date(isoStr);
+  if (isNaN(d.getTime())) return isoStr;
+  const secs = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (secs < 60) return 'just now';
+  if (secs < 3600) return Math.floor(secs / 60) + ' min ago';
+  if (secs < 86400) return Math.floor(secs / 3600) + 'h ago';
+  return Math.floor(secs / 86400) + 'd ago';
+}
+
+// Deterministic hashed color for squad chip background.
+function squadColor(name) {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  const hue = ((h % 360) + 360) % 360;
+  return `hsl(${hue}, 50%, 25%)`;
+}
+
+// Determine the left-border CSS class for a card based on status + failure_reason.
+function cardBorderClass(op) {
+  if (op.status === 'failed' && op.failure_reason) {
+    const entry = typeof FAILURE_REASONS !== 'undefined' ? FAILURE_REASONS[op.failure_reason] : null;
+    if (entry) return 'border-' + entry.bucket;
+    return 'border-crashed'; // unknown failure_reason defaults to red
+  }
+  if (op.status === 'active' || op.status === 'queued') return 'border-active';
+  if (op.status === 'completed') return 'border-completed';
+  return '';
+}
+
+// Determine the status-dot CSS class (for detail view, etc.)
+function statusDotClass(op) {
+  if (op.status === 'failed' && op.failure_reason) {
+    const entry = typeof FAILURE_REASONS !== 'undefined' ? FAILURE_REASONS[op.failure_reason] : null;
+    if (entry) return entry.bucket;
+  }
+  return op.status;
+}
+
 function renderOpCard(op, container) {
   const card = document.createElement('div');
-  card.className = 'op-card' + (selectedOp === op.id ? ' selected' : '');
+  const border = cardBorderClass(op);
+  card.className = 'op-card' + (border ? ' ' + border : '') + (selectedOp === op.id ? ' selected' : '');
   card.onclick = () => selectOp(op);
-  card.innerHTML = `
-    <div class="op-squad"><span class="status-dot ${op.status}"></span>${op.squad}</div>
-    <div class="op-id">${op.id}</div>
-    <div class="op-meta">
-      <span>${op.elapsed || '—'}</span>
-      <span>${op.summary ? op.summary.substring(0, 60) + (op.summary.length > 60 ? '...' : '') : op.brief || ''}</span>
-    </div>
-  `;
+
+  // Title: summary > brief (sanitized) > id as last resort
+  const titleText = op.summary || sanitizeBrief(op.brief) || op.id;
+  const fullTitle = op.summary || op.brief || op.id;
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'op-title';
+  titleEl.textContent = titleText;
+  titleEl.title = fullTitle;
+  card.appendChild(titleEl);
+
+  // Meta row: squad chip + relative time
+  const metaRow = document.createElement('div');
+  metaRow.className = 'op-meta-row';
+
+  if (op.squad) {
+    const chip = document.createElement('span');
+    chip.className = 'squad-chip';
+    chip.textContent = op.squad;
+    chip.style.backgroundColor = squadColor(op.squad);
+    metaRow.appendChild(chip);
+  }
+
+  const dot = document.createElement('span');
+  dot.className = 'status-dot ' + statusDotClass(op);
+  metaRow.appendChild(dot);
+
+  if (op.created_at) {
+    const timeEl = document.createElement('span');
+    timeEl.textContent = relativeTime(op.created_at);
+    timeEl.title = op.created_at;
+    metaRow.appendChild(timeEl);
+  }
+
+  card.appendChild(metaRow);
+
+  // Op ID: muted, bottom-right, click-to-copy
+  const idLine = document.createElement('div');
+  idLine.className = 'op-id-line';
+  idLine.textContent = op.id;
+  idLine.title = 'Click to copy';
+  idLine.onclick = (e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(op.id).then(() => toast('Copied: ' + op.id)).catch(() => {});
+  };
+  card.appendChild(idLine);
+
   container.appendChild(card);
+}
+
+// Failure bucket → failure_reason identifiers mapping for client-side filtering.
+const BUCKET_REASONS = {
+  cancelled: ['cancelled_by_user'],
+  crashed: ['process_exited_without_completion'],
+  setup: ['classify_spawn_failed', 'classify_move_failed', 'provision_failed', 'launch_failed'],
+  config: ['classify_no_squad', 'classify_squad_not_installed'],
+};
+
+// Parse the dropdown value. Returns { status, bucket } where bucket is null
+// for non-sub-filtered selections.
+function parseFilterValue(dropdown) {
+  if (!dropdown) return { status: null, bucket: null };
+  if (dropdown.startsWith('failed:')) return { status: 'failed', bucket: dropdown.slice(7) };
+  return { status: dropdown, bucket: null };
 }
 
 // Compute the status filter for the active list.
@@ -240,8 +349,9 @@ function renderOpCard(op, container) {
 // - Dropdown matches an "active-bucket" status → that single status
 // - Dropdown matches a terminal status → active list is empty (filter excludes it)
 function activeStatusFilter(dropdown) {
-  if (!dropdown) return ACTIVE_STATUSES;
-  if (dropdown === 'active' || dropdown === 'queued') return dropdown;
+  const { status } = parseFilterValue(dropdown);
+  if (!status) return ACTIVE_STATUSES;
+  if (status === 'active' || status === 'queued') return status;
   return null; // active list shows empty state
 }
 
@@ -250,13 +360,23 @@ function activeStatusFilter(dropdown) {
 // - Dropdown matches a terminal status → that single status
 // - Dropdown matches an active-bucket status → history list is empty
 function historyStatusFilter(dropdown) {
-  if (!dropdown) return HISTORY_STATUSES;
-  if (dropdown === 'active' || dropdown === 'queued') return null;
-  return dropdown;
+  const { status } = parseFilterValue(dropdown);
+  if (!status) return HISTORY_STATUSES;
+  if (status === 'active' || status === 'queued') return null;
+  return status;
+}
+
+// Client-side failure_reason sub-filter. Returns ops filtered by bucket.
+function applyBucketFilter(ops, dropdown) {
+  const { bucket } = parseFilterValue(dropdown);
+  if (!bucket) return ops;
+  const reasons = BUCKET_REASONS[bucket];
+  if (!reasons) return ops;
+  return ops.filter(op => reasons.includes(op.failure_reason));
 }
 
 function renderEmpty(container, text) {
-  container.innerHTML = `<div style="padding:8px 12px;color:var(--fg2);font-size:13px;">${text}</div>`;
+  container.innerHTML = `<div style="padding:8px 12px;color:var(--color-fg-muted);font-size:13px;">${text}</div>`;
 }
 
 // --- Active list (independent query, frequent polling) ---
@@ -284,8 +404,12 @@ async function loadActiveOps() {
     activeList.innerHTML = '';
     if (ops.length === 0) {
       renderEmpty(activeList, 'No active operations');
+      lastActiveCount = 0;
+      updateSectionCounts();
       return;
     }
+    lastActiveCount = ops.length;
+    updateSectionCounts();
     ops.forEach(op => renderOpCard(op, activeList));
   } catch(e) {
     // Leave previous content intact on transient failure to avoid flicker.
@@ -327,8 +451,12 @@ async function loadHistoryOps(reset = true) {
   try {
     const resp = await fetch(`/api/ops?${params}`);
     const data = await resp.json();
-    const ops = data.operations || [];
+    let ops = data.operations || [];
+    // Client-side sub-filter by failure_reason bucket
+    ops = applyBucketFilter(ops, dropdown);
     historyTotal = data.total || 0;
+    lastHistoryCount = historyTotal;
+    updateSectionCounts();
     ops.forEach(op => renderOpCard(op, historyList));
     historyOffset += ops.length;
     // If a non-reset page returned 0 ops while the server still claims more
@@ -354,13 +482,26 @@ async function loadMore() {
 
 // --- Stats (independent fetch and interval) ---
 
+// Track latest counts for section titles
+let lastActiveCount = 0;
+let lastHistoryCount = 0;
+
+function updateSectionCounts() {
+  const activeTitle = document.getElementById('section-active-title');
+  const historyTitle = document.getElementById('section-history-title');
+  if (activeTitle) activeTitle.textContent = `Active (${lastActiveCount})`;
+  if (historyTitle) historyTitle.textContent = `History (${lastHistoryCount})`;
+}
+
 async function loadStats() {
   try {
     const resp = await fetch('/api/stats');
     const stats = await resp.json();
     document.getElementById('stat-active').textContent = `Active: ${(stats.active || 0) + (stats.queued || 0)}`;
-    document.getElementById('stat-completed').textContent = `Completed: ${stats.completed || 0}`;
-    document.getElementById('stat-failed').textContent = `Failed: ${stats.failed || 0}`;
+    document.getElementById('stat-cancelled').textContent = `Cancelled: ${stats.cancelled || 0}`;
+    document.getElementById('stat-crashed').textContent = `Crashed: ${stats.crashed || 0}`;
+    document.getElementById('stat-setup').textContent = `Setup: ${stats.setup || 0}`;
+    document.getElementById('stat-config').textContent = `Config: ${stats.config || 0}`;
   } catch(e) {
     // Keep prior values on transient failure.
   }
@@ -392,24 +533,65 @@ async function selectOp(op) {
   content.style.display = '';
 
   // Build metadata section
+  const dotClass = statusDotClass(op);
+  const createdRel = relativeTime(op.created_at);
+  const completedRel = op.completed_at ? relativeTime(op.completed_at) : 'running';
   let html = `
     <div class="detail-field">
       <div class="detail-label">Operation</div>
-      <div class="detail-value">${escapeHtml(op.id)} &nbsp; <span class="status-dot ${op.status}"></span>${escapeHtml(op.status)}</div>
+      <div class="detail-value">${escapeHtml(op.id)} &nbsp; <span class="status-dot ${dotClass}"></span>${escapeHtml(op.status)}</div>
     </div>
     <div class="detail-field">
       <div class="detail-label">Squad</div>
-      <div class="detail-value">${escapeHtml(op.squad)}</div>
+      <div class="detail-value"><span class="squad-chip" style="background:${squadColor(op.squad || '')}">${escapeHtml(op.squad)}</span></div>
     </div>
     <div class="detail-field">
       <div class="detail-label">Brief</div>
-      <div class="detail-value">${escapeHtml(op.brief || '—')}</div>
+      <div class="detail-value">${escapeHtml(op.brief || '\u2014')}</div>
     </div>
     ${op.summary ? `<div class="detail-field"><div class="detail-label">Summary</div><div class="detail-value">${escapeHtml(op.summary)}</div></div>` : ''}
     <div class="detail-field">
       <div class="detail-label">Duration</div>
-      <div class="detail-value">${escapeHtml(op.elapsed || '—')} &nbsp; (${escapeHtml(op.created_at || '?')} → ${escapeHtml(op.completed_at || 'running')})</div>
+      <div class="detail-value">${escapeHtml(op.elapsed || '\u2014')} &nbsp; (<span title="${escapeHtml(op.created_at || '')}">${escapeHtml(createdRel || '?')}</span> \u2192 <span title="${escapeHtml(op.completed_at || '')}">${escapeHtml(completedRel)}</span>)</div>
     </div>
+  `;
+
+  // Failure block: structured display when op has a failure_reason
+  if (op.status === 'failed' && op.failure_reason && typeof FAILURE_REASONS !== 'undefined') {
+    const fr = FAILURE_REASONS[op.failure_reason];
+    if (fr) {
+      let actionsHtml = '';
+      if (fr.action) {
+        if (fr.action.file) {
+          actionsHtml = `<button class="failure-action-btn" onclick="loadFileContent('${escapeHtml(op.id)}','${escapeHtml(fr.action.file)}',document.querySelector('.file-tabs'))">${escapeHtml(fr.action.label)}</button>`;
+        } else if (fr.action.href) {
+          actionsHtml = `<a class="failure-action-btn" href="${escapeHtml(fr.action.href)}">${escapeHtml(fr.action.label)}</a>`;
+        } else {
+          actionsHtml = `<span class="failure-action-btn">${escapeHtml(fr.action.label)}</span>`;
+        }
+      }
+      html += `
+    <div class="detail-field">
+      <div class="detail-label">Failure</div>
+      <div class="failure-block">
+        <div class="failure-header"><span>${fr.icon}</span> ${escapeHtml(fr.label)}</div>
+        <div class="failure-code">${escapeHtml(op.failure_reason)}</div>
+        <div class="failure-hint">${escapeHtml(fr.hint)}</div>
+        ${actionsHtml ? `<div class="failure-actions">${actionsHtml}</div>` : ''}
+      </div>
+    </div>
+      `;
+    }
+  } else if (op.status === 'failed' && op.failure_reason) {
+    html += `
+    <div class="detail-field">
+      <div class="detail-label">Failure Reason</div>
+      <div class="detail-value">${escapeHtml(op.failure_reason)}</div>
+    </div>
+    `;
+  }
+
+  html += `
     <div id="file-tabs-container"></div>
     <div class="detail-field">
       <div id="file-content-label" class="detail-label">OPERATION.md</div>
@@ -619,7 +801,7 @@ async function loadRuntimes(skipAutoConnect) {
     if (target) {
       connectSession(target.name);
     } else {
-      document.getElementById('terminal-placeholder').innerHTML = '<div style="color:var(--fg2);font-size:14px;">No CLI runtimes installed</div>';
+      document.getElementById('terminal-placeholder').innerHTML = '<div style="color:var(--color-fg-muted);font-size:14px;">No CLI runtimes installed</div>';
     }
   } catch(e) {}
 }

--- a/static/failureReasons.js
+++ b/static/failureReasons.js
@@ -1,0 +1,59 @@
+// Centralised dictionary mapping failure_reason identifiers to UX buckets.
+// Source of truth for the dashboard — if swat renames an enum, the regression
+// test (failureReasons.test.js) breaks immediately.
+
+const FAILURE_REASONS = {
+  cancelled_by_user: {
+    bucket: 'cancelled', label: 'Cancelled', icon: '\u{274C}',
+    hint: 'User cancelled this operation.', action: null,
+  },
+  process_exited_without_completion: {
+    bucket: 'crashed', label: 'Crashed', icon: '\u{1F4A5}',
+    hint: 'The agent exited without writing a completion. Inspect the agent log.',
+    action: { label: 'View agent log', file: 'agent.log' },
+  },
+  classify_spawn_failed: {
+    bucket: 'setup', label: 'Setup Failed', icon: '\u{1F6E0}\u{FE0F}',
+    hint: 'Could not start the classifier process.',
+    action: { label: 'View classify log', file: 'classify.log' },
+  },
+  classify_move_failed: {
+    bucket: 'setup', label: 'Setup Failed', icon: '\u{1F6E0}\u{FE0F}',
+    hint: 'Could not move the operation into its squad directory \u2014 usually a transient file lock. Retry.',
+    action: { label: 'Retry dispatch', kind: 'redispatch' },
+  },
+  provision_failed: {
+    bucket: 'setup', label: 'Setup Failed', icon: '\u{1F6E0}\u{FE0F}',
+    hint: 'Workspace provisioning failed.',
+    action: { label: 'View classify log', file: 'classify.log' },
+  },
+  launch_failed: {
+    bucket: 'setup', label: 'Setup Failed', icon: '\u{1F6E0}\u{FE0F}',
+    hint: 'Agent could not be launched after provisioning.',
+    action: { label: 'View classify log', file: 'classify.log' },
+  },
+  classify_no_squad: {
+    bucket: 'config', label: 'No Squad', icon: '\u{1F4E6}',
+    hint: 'Classifier did not match any installed squad. Install or extend a squad\u2019s scope.',
+    action: { label: 'Browse squads', href: '#squads' },
+  },
+  classify_squad_not_installed: {
+    bucket: 'config', label: 'Squad Missing', icon: '\u{1F4E6}',
+    hint: 'Classified to a squad that is not installed locally.',
+    action: { label: 'Install squad', kind: 'install' },
+  },
+};
+
+const FAILURE_BUCKETS = {
+  cancelled: { label: 'Cancelled', dotClass: 'cancelled' },
+  crashed:   { label: 'Crashed',   dotClass: 'crashed'   },
+  setup:     { label: 'Setup',     dotClass: 'setup'     },
+  config:    { label: 'Config',    dotClass: 'config'    },
+};
+
+// Resolve a failure_reason string to its bucket info, or null if unknown.
+function getFailureBucket(reason) {
+  const entry = FAILURE_REASONS[reason];
+  if (!entry) return null;
+  return FAILURE_BUCKETS[entry.bucket] || null;
+}

--- a/static/failureReasons.test.js
+++ b/static/failureReasons.test.js
@@ -1,0 +1,60 @@
+// Regression test for failureReasons.js — ensures all known swat
+// failure_reason enum identifiers are mapped in the centralised dictionary.
+// Run with: node --test static/failureReasons.test.js
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Load failureReasons.js into this context (it uses plain globals, not ESM)
+const src = fs.readFileSync(path.join(__dirname, 'failureReasons.js'), 'utf8');
+const fn = new Function(src + '\nreturn { FAILURE_REASONS, FAILURE_BUCKETS, getFailureBucket };');
+const { FAILURE_REASONS, FAILURE_BUCKETS, getFailureBucket } = fn();
+
+// The 8 canonical failure_reason identifiers from swat/commander/operation.
+const KNOWN_ENUMS = [
+  'cancelled_by_user',
+  'process_exited_without_completion',
+  'classify_spawn_failed',
+  'classify_no_squad',
+  'classify_squad_not_installed',
+  'classify_move_failed',
+  'provision_failed',
+  'launch_failed',
+];
+
+describe('failureReasons dictionary', () => {
+  it('maps all 8 known failure_reason enums', () => {
+    for (const k of KNOWN_ENUMS) {
+      assert.ok(FAILURE_REASONS[k], `missing mapping for ${k}`);
+    }
+  });
+
+  it('every mapped entry has required fields', () => {
+    for (const [key, entry] of Object.entries(FAILURE_REASONS)) {
+      assert.ok(entry.bucket, `${key}: missing bucket`);
+      assert.ok(entry.label, `${key}: missing label`);
+      assert.ok(entry.hint, `${key}: missing hint`);
+      assert.ok(FAILURE_BUCKETS[entry.bucket], `${key}: bucket "${entry.bucket}" not in FAILURE_BUCKETS`);
+    }
+  });
+
+  it('FAILURE_BUCKETS has all expected buckets', () => {
+    for (const b of ['cancelled', 'crashed', 'setup', 'config']) {
+      assert.ok(FAILURE_BUCKETS[b], `missing bucket: ${b}`);
+      assert.ok(FAILURE_BUCKETS[b].label, `bucket ${b}: missing label`);
+      assert.ok(FAILURE_BUCKETS[b].dotClass, `bucket ${b}: missing dotClass`);
+    }
+  });
+
+  it('getFailureBucket resolves known reasons', () => {
+    const result = getFailureBucket('cancelled_by_user');
+    assert.ok(result);
+    assert.equal(result.dotClass, 'cancelled');
+  });
+
+  it('getFailureBucket returns null for unknown reasons', () => {
+    assert.equal(getFailureBucket('unknown_reason'), null);
+  });
+});

--- a/static/index.html
+++ b/static/index.html
@@ -13,17 +13,19 @@
   <h1>⚡ SWAT Dashboard</h1>
   <div class="stats">
     <span class="stat active" id="stat-active">Active: 0</span>
-    <span class="stat" id="stat-completed">Completed: 0</span>
-    <span class="stat failed" id="stat-failed">Failed: 0</span>
+    <span class="stat cancelled" id="stat-cancelled">Cancelled: 0</span>
+    <span class="stat crashed" id="stat-crashed">Crashed: 0</span>
+    <span class="stat setup" id="stat-setup">Setup: 0</span>
+    <span class="stat config" id="stat-config">Config: 0</span>
   </div>
 </div>
 
 <div class="main">
   <div class="left">
-    <div class="section-title">Active</div>
+    <div class="section-title" id="section-active-title">Active</div>
     <div class="active-list" id="active-list"></div>
 
-    <div class="section-title">History</div>
+    <div class="section-title" id="section-history-title">History</div>
     <div class="filters">
       <select id="filter-squad"><option value="">All Squads</option></select>
       <select id="filter-status">
@@ -32,7 +34,10 @@
         <option value="queued">Queued</option>
         <option value="completed">Completed</option>
         <option value="failed">Failed</option>
-        <option value="cancelled">Cancelled</option>
+        <option value="failed:crashed">&nbsp;&nbsp;↳ Crashed</option>
+        <option value="failed:setup">&nbsp;&nbsp;↳ Setup Failed</option>
+        <option value="failed:config">&nbsp;&nbsp;↳ Config Needed</option>
+        <option value="failed:cancelled">&nbsp;&nbsp;↳ Cancelled</option>
       </select>
       <input type="text" id="filter-keyword" placeholder="Search...">
     </div>
@@ -67,6 +72,7 @@
 <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.1/dist/purify.min.js"></script>
+<script src="failureReasons.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,56 +1,87 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 :root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d;
-  --fg: #c9d1d9; --fg2: #8b949e; --accent: #58a6ff;
-  --green: #3fb950; --red: #f85149; --yellow: #d29922;
-  --border: #30363d;
+  --color-canvas-default: #0d1117;
+  --color-canvas-overlay: #161b22;
+  --color-canvas-subtle: #21262d;
+  --color-fg-default: #e6edf3;
+  --color-fg-muted: #7d8590;
+  --color-accent-fg: #58a6ff;
+  --color-success-fg: #3fb950;
+  --color-danger-fg: #f85149;
+  --color-attention-fg: #d29922;
+  --color-done-fg: #a371f7;
+  --color-border-default: #30363d;
+  --font-mono: 'SF Mono', 'JetBrains Mono', 'Cascadia Code', Consolas, ui-monospace, monospace;
 }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--fg); height: 100vh; display: flex; flex-direction: column; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--color-canvas-default); color: var(--color-fg-default); height: 100vh; display: flex; flex-direction: column; }
 
 /* Header */
-.header { display: flex; align-items: center; padding: 12px 20px; background: var(--bg2); border-bottom: 1px solid var(--border); gap: 16px; }
+.header { display: flex; align-items: center; padding: 12px 20px; background: var(--color-canvas-overlay); border-bottom: 1px solid var(--color-border-default); gap: 16px; }
 .header h1 { font-size: 16px; font-weight: 600; }
-.header .stats { display: flex; gap: 12px; margin-left: auto; font-size: 13px; }
-.stat { padding: 4px 10px; border-radius: 12px; background: var(--bg3); }
-.stat.active { color: var(--green); }
-.stat.failed { color: var(--red); }
+.header .stats { display: flex; gap: 8px; margin-left: auto; font-size: 13px; flex-wrap: wrap; }
+.stat { padding: 4px 10px; border-radius: 12px; background: var(--color-canvas-subtle); }
+.stat.active { color: var(--color-success-fg); }
+.stat.failed { color: var(--color-danger-fg); }
+.stat.cancelled { color: var(--color-fg-muted); }
+.stat.crashed { color: var(--color-danger-fg); }
+.stat.setup { color: var(--color-attention-fg); }
+.stat.config { color: var(--color-done-fg); }
 
 /* Main layout */
 .main { display: flex; flex: 1; overflow: hidden; }
 
 /* Left panel */
-.left { width: 340px; min-width: 280px; border-right: 1px solid var(--border); display: flex; flex-direction: column; background: var(--bg2); }
-.section-title { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--fg2); padding: 12px 16px 6px; letter-spacing: 0.5px; }
+.left { width: 340px; min-width: 280px; border-right: 1px solid var(--color-border-default); display: flex; flex-direction: column; background: var(--color-canvas-overlay); }
+.section-title { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--color-fg-muted); padding: 12px 16px 6px; letter-spacing: 0.5px; }
 
 /* Active ops */
 .active-list { padding: 0 8px 8px; }
-.op-card { padding: 10px 12px; margin: 4px 0; border-radius: 8px; cursor: pointer; transition: background 0.15s; }
-.op-card:hover { background: var(--bg3); }
-.op-card.selected { background: var(--bg3); border-left: 3px solid var(--accent); }
-.op-id { font-size: 12px; font-family: monospace; color: var(--fg2); }
+.op-card { padding: 10px 12px; margin: 4px 0; border-radius: 8px; cursor: pointer; transition: background 0.15s; border-left: 4px solid transparent; position: relative; }
+.op-card:hover { background: rgba(255,255,255,0.04); }
+.op-card.selected { border: 1px solid var(--color-accent-fg); border-left: 4px solid var(--color-accent-fg); }
+.op-card.selected .op-title { font-weight: 600; }
+.op-card.border-cancelled { border-left-color: var(--color-fg-muted); }
+.op-card.border-crashed { border-left-color: var(--color-danger-fg); }
+.op-card.border-setup { border-left-color: var(--color-attention-fg); }
+.op-card.border-config { border-left-color: var(--color-done-fg); }
+.op-card.border-active { border-left-color: var(--color-success-fg); }
+.op-card.border-completed { border-left-color: var(--color-fg-muted); }
+
+.op-title { font-size: 14px; font-weight: 500; color: var(--color-fg-default); display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; line-height: 1.4; }
+.op-meta-row { display: flex; align-items: center; gap: 8px; margin-top: 4px; font-size: 12px; color: var(--color-fg-muted); }
+.op-id-line { font-size: 11px; font-family: var(--font-mono); color: var(--color-fg-muted); text-align: right; margin-top: 4px; cursor: pointer; }
+.op-id-line:hover { color: var(--color-accent-fg); }
+
+.squad-chip { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 500; color: var(--color-fg-default); }
+
+.op-id { font-size: 12px; font-family: var(--font-mono); color: var(--color-fg-muted); }
 .op-squad { font-size: 13px; font-weight: 500; margin: 2px 0; }
-.op-meta { font-size: 11px; color: var(--fg2); display: flex; gap: 8px; }
+.op-meta { font-size: 11px; color: var(--color-fg-muted); display: flex; gap: 8px; }
 .status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; }
-.status-dot.active, .status-dot.queued { background: var(--green); animation: pulse 2s infinite; }
-.status-dot.completed { background: var(--fg2); }
-.status-dot.failed { background: var(--red); }
+.status-dot.active, .status-dot.queued { background: var(--color-success-fg); animation: pulse 2s infinite; }
+.status-dot.completed { background: var(--color-fg-muted); }
+.status-dot.failed { background: var(--color-danger-fg); }
+.status-dot.cancelled { background: var(--color-fg-muted); }
+.status-dot.crashed { background: var(--color-danger-fg); }
+.status-dot.setup { background: var(--color-attention-fg); }
+.status-dot.config { background: var(--color-done-fg); }
 @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 /* Filters */
-.filters { padding: 8px 12px; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); display: flex; gap: 6px; flex-wrap: wrap; }
-.filters select, .filters input { background: var(--bg); border: 1px solid var(--border); color: var(--fg); border-radius: 6px; padding: 5px 8px; font-size: 12px; }
+.filters { padding: 8px 12px; border-top: 1px solid var(--color-border-default); border-bottom: 1px solid var(--color-border-default); display: flex; gap: 6px; flex-wrap: wrap; }
+.filters select, .filters input { background: var(--color-canvas-default); border: 1px solid var(--color-border-default); color: var(--color-fg-default); border-radius: 6px; padding: 5px 8px; font-size: 12px; }
 .filters input { flex: 1; min-width: 80px; }
 
 /* History list */
 .history-list { flex: 1; overflow-y: auto; padding: 0 8px; }
 .load-more { text-align: center; padding: 12px; }
-.load-more button { background: var(--bg3); border: 1px solid var(--border); color: var(--accent); padding: 6px 16px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+.load-more button { background: var(--color-canvas-subtle); border: 1px solid var(--color-border-default); color: var(--color-accent-fg); padding: 6px 16px; border-radius: 6px; cursor: pointer; font-size: 12px; }
 
 /* Right panel */
 .right { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-.right-header { display: flex; align-items: center; padding: 8px 16px; background: var(--bg2); border-bottom: 1px solid var(--border); gap: 8px; }
-.tab { padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px; color: var(--fg2); }
-.tab.active { background: var(--bg3); color: var(--fg); }
+.right-header { display: flex; align-items: center; padding: 8px 16px; background: var(--color-canvas-overlay); border-bottom: 1px solid var(--color-border-default); gap: 8px; }
+.tab { padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px; color: var(--color-fg-muted); }
+.tab.active { background: var(--color-canvas-subtle); color: var(--color-fg-default); }
 .right-content { flex: 1; overflow: hidden; position: relative; }
 
 /* Terminal */
@@ -63,29 +94,38 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 #detail-view { width: 100%; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 20px; display: none; min-width: 0; overflow-wrap: anywhere; }
 #detail-view.visible { display: block; }
 .detail-field { margin-bottom: 16px; min-width: 0; }
-.detail-label { font-size: 11px; text-transform: uppercase; color: var(--fg2); margin-bottom: 4px; letter-spacing: 0.5px; }
+.detail-label { font-size: 11px; text-transform: uppercase; color: var(--color-fg-muted); margin-bottom: 4px; letter-spacing: 0.5px; }
 .detail-value { font-size: 14px; line-height: 1.6; overflow-wrap: anywhere; word-break: break-word; }
-.detail-value pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-word; max-width: 100%; }
+.detail-value pre { background: var(--color-canvas-overlay); padding: 12px; border-radius: 8px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-word; max-width: 100%; font-family: var(--font-mono); }
+
+/* Failure block in detail view */
+.failure-block { background: var(--color-canvas-overlay); border: 1px solid var(--color-border-default); border-radius: 8px; padding: 16px; margin-top: 8px; }
+.failure-block .failure-header { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+.failure-block .failure-code { font-size: 12px; font-family: var(--font-mono); color: var(--color-fg-muted); margin-bottom: 8px; }
+.failure-block .failure-hint { font-size: 13px; color: var(--color-fg-muted); line-height: 1.5; margin-bottom: 12px; }
+.failure-block .failure-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.failure-block .failure-action-btn { padding: 6px 14px; border-radius: 6px; font-size: 12px; cursor: pointer; border: 1px solid var(--color-border-default); background: var(--color-canvas-subtle); color: var(--color-accent-fg); text-decoration: none; display: inline-block; }
+.failure-block .failure-action-btn:hover { background: var(--color-canvas-default); }
 
 /* File tabs */
-.file-tabs { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
-.file-tab { padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 12px; color: var(--fg2); background: transparent; border: 1px solid transparent; font-family: monospace; }
-.file-tab:hover { background: var(--bg3); }
-.file-tab.active { background: var(--bg3); color: var(--fg); border-color: var(--border); }
+.file-tabs { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--color-border-default); }
+.file-tab { padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 12px; color: var(--color-fg-muted); background: transparent; border: 1px solid transparent; font-family: var(--font-mono); }
+.file-tab:hover { background: var(--color-canvas-subtle); }
+.file-tab.active { background: var(--color-canvas-subtle); color: var(--color-fg-default); border-color: var(--color-border-default); }
 
 /* Rendered markdown */
 .md-content { line-height: 1.7; overflow-wrap: anywhere; word-break: break-word; }
-.md-content h1, .md-content h2, .md-content h3 { margin: 16px 0 8px; color: var(--fg); }
-.md-content code { background: var(--bg3); padding: 2px 6px; border-radius: 4px; font-size: 13px; overflow-wrap: anywhere; word-break: break-word; }
-.md-content pre { background: var(--bg2); padding: 12px; border-radius: 8px; overflow-x: auto; max-width: 100%; }
+.md-content h1, .md-content h2, .md-content h3 { margin: 16px 0 8px; color: var(--color-fg-default); }
+.md-content code { background: var(--color-canvas-subtle); padding: 2px 6px; border-radius: 4px; font-size: 13px; overflow-wrap: anywhere; word-break: break-word; font-family: var(--font-mono); }
+.md-content pre { background: var(--color-canvas-overlay); padding: 12px; border-radius: 8px; overflow-x: auto; max-width: 100%; }
 .md-content pre code { background: none; padding: 0; }
-.md-content a { color: var(--accent); overflow-wrap: anywhere; word-break: break-word; }
+.md-content a { color: var(--color-accent-fg); overflow-wrap: anywhere; word-break: break-word; }
 .md-content ul, .md-content ol { padding-left: 24px; }
-.md-content blockquote { border-left: 3px solid var(--border); padding-left: 12px; color: var(--fg2); }
+.md-content blockquote { border-left: 3px solid var(--color-border-default); padding-left: 12px; color: var(--color-fg-muted); }
 .md-content img { max-width: 100%; height: auto; }
 .md-content table { display: block; max-width: 100%; overflow-x: auto; border-collapse: collapse; margin: 8px 0; }
-.md-content th, .md-content td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; }
-.md-content th { background: var(--bg2); font-weight: 600; }
+.md-content th, .md-content td { padding: 6px 10px; border: 1px solid var(--color-border-default); text-align: left; }
+.md-content th { background: var(--color-canvas-overlay); font-weight: 600; }
 
 /* Narrow viewport: tighten container padding so content has room to breathe */
 @media (max-width: 600px) {
@@ -94,8 +134,8 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 
 /* HTML iframe — auto-sized to content height by JS so the outer #detail-view
    scroll handles long content instead of producing a nested scrollbar. */
-.html-frame { width: 100%; border: 1px solid var(--border); border-radius: 8px; background: #fff; display: block; }
-.open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--bg3); border: 1px solid var(--border); color: var(--accent); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
+.html-frame { width: 100%; border: 1px solid var(--color-border-default); border-radius: 8px; background: #fff; display: block; }
+.open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--color-canvas-subtle); border: 1px solid var(--color-border-default); color: var(--color-accent-fg); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
 
 /* Empty state */
-.empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--fg2); font-size: 14px; }
+.empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--color-fg-muted); font-size: 14px; }


### PR DESCRIPTION
## What
Implement issue #23: full operation status & card UX redesign with failure_reason bucket system, card visual hierarchy rewrite, and Primer Dark CSS adoption.

## Why
swat#96 standardized failure_reason into 8 enumerated identifiers. The dashboard needs to surface these as actionable UX — mapping them to 4 user-facing buckets (cancelled/crashed/setup/config) with appropriate colors, icons, hints, and next-action guidance.

## Changes
- go.mod: Bump swat v1.2.0 to v1.2.2
- main.go: Add FailureReason to OpView; return bucket counts in /api/stats
- static/failureReasons.js: Centralised dictionary (8 enums, 4 buckets)
- static/app.js: Rewrite renderOpCard, brief sanitizer, relative time, squad chip, click-to-copy, filters, failure block
- static/style.css: Primer Dark tokens, bucket colors, failure-block styles, monospace stack
- static/index.html: Updated stats bar, filter dropdown sub-options, section counts
- static/failureReasons.test.js: Regression test (node:test, 5 tests)
- README.md: Primer Dark design contract

## How to Test
1. go build -o /dev/null . — passes
2. go test ./... — passes
3. node --test static/failureReasons.test.js — 5/5 pass

Closes #23