### PR TITLE
fix: skip --resume flag for Gemini runtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,6 +260,16 @@ var (
 // fallback (and by /api/runtimes for stable client rendering).
 var runtimeOrder = []string{"copilot", "gemini"}
 
+// resumeSupported indicates which runtimes support `--resume <guid>` to
+// reattach to an existing conversation session. Copilot creates the session on
+// first use (create-on-miss); Gemini only attaches to existing sessions — a
+// freshly-minted UUID that has never been seen before causes an immediate
+// failure. See issue #32.
+var resumeSupported = map[string]bool{
+	"copilot": true,
+	"gemini":  false,
+}
+
 // Test-only hooks. These are package vars so individual tests can override
 // them to exercise concurrency-sensitive paths without depending on a real
 // CLI being installed. Production callers are unaffected.
@@ -379,7 +389,7 @@ func createPTYSession(runtimeName, prompt string) (*platformPTY, error) {
 	// history; `-i` injects the operator-level system prompt). Issue #29
 	// confirms this orthogonality.
 	var args []string
-	if sessionStore != nil {
+	if resumeSupported[runtimeName] && sessionStore != nil {
 		guid := sessionStore.GUIDFor(runtimeName)
 		if guid != "" {
 			args = append(args, "--resume", guid)


### PR DESCRIPTION
## What
Skip passing `--resume <guid>` to Gemini CLI, which does not support create-on-miss session IDs.

Fixes #32

## Why
`createPTYSession` was passing `--resume <freshly-minted-uuid>` for ALL runtimes. Copilot creates the session on first use (create-on-miss), but Gemini only attaches to existing sessions — so a new UUID that has never been seen before fails immediately.

## Changes
- `main.go`: Added `resumeSupported` capability map (`copilot: true`, `gemini: false`). Modified the `--resume` arg construction in `createPTYSession` to gate on `resumeSupported[runtimeName]` before appending the flag.

## How to Test
1. On a fresh machine with no prior Gemini sessions, run the dashboard — Gemini should launch successfully without `--resume`
2. Copilot resume behavior is unchanged — UUID from sessions.json is still passed via `--resume`
3. Runtime switching (gemini → copilot → gemini) works, just without conversation persistence on the Gemini side
4. `go build ./...` passes