### PR TITLE
feat: detail page improvements — issue #27

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,15 +38,22 @@ var upgrader = websocket.Upgrader{
 
 // OpView is a lightweight UI view of an operation
 type OpView struct {
-	ID            string `json:"id"`
-	Squad         string `json:"squad"`
-	Status        string `json:"status"`
-	Brief         string `json:"brief"`
-	Summary       string `json:"summary"`
-	FailureReason string `json:"failure_reason,omitempty"`
-	CreatedAt     string `json:"created_at"`
-	CompletedAt   string `json:"completed_at,omitempty"`
-	Elapsed       string `json:"elapsed,omitempty"`
+	ID            string    `json:"id"`
+	Squad         string    `json:"squad"`
+	Status        string    `json:"status"`
+	Brief         string    `json:"brief"`
+	Summary       string    `json:"summary"`
+	FailureReason string    `json:"failure_reason,omitempty"`
+	CreatedAt     string    `json:"created_at"`
+	CompletedAt   string    `json:"completed_at,omitempty"`
+	Elapsed       string    `json:"elapsed,omitempty"`
+	References    []RefView `json:"references,omitempty"`
+}
+
+// RefView is a typed reference for the UI
+type RefView struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 func opToView(op *operation.Operation) OpView {
@@ -59,6 +66,9 @@ func opToView(op *operation.Operation) OpView {
 	}
 	if op.FailureReason != nil {
 		v.FailureReason = *op.FailureReason
+	}
+	for _, ref := range op.References {
+		v.References = append(v.References, RefView{Type: ref.Type, Value: ref.Value})
 	}
 	if !op.CreatedAt.IsZero() {
 		v.CreatedAt = op.CreatedAt.Format(time.RFC3339)

--- a/static/app.js
+++ b/static/app.js
@@ -540,12 +540,8 @@ async function selectOp(op) {
   const completedRel = op.completed_at ? relativeTime(op.completed_at) : 'running';
 
   // #1 Markdown render brief/summary
-  const briefHtml = (op.brief && typeof marked !== 'undefined')
-    ? (typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(marked.parse(op.brief)) : marked.parse(op.brief))
-    : escapeHtml(op.brief || '\u2014');
-  const summaryHtml = (op.summary && typeof marked !== 'undefined')
-    ? (typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(marked.parse(op.summary)) : marked.parse(op.summary))
-    : '';
+  const briefHtml = renderMarkdown(op.brief);
+  const summaryHtml = op.summary ? renderMarkdown(op.summary) : '';
 
   // #2 Sidebar metadata layout (right sidebar) + main column
   let html = '<div class="detail-layout">';
@@ -608,7 +604,8 @@ async function selectOp(op) {
     op.references.forEach(ref => {
       const val = escapeHtml(ref.value);
       if (ref.type === 'operation') {
-        refsInner += `<li><a href="#" class="ref-link" data-op-id="${val}">${val}</a></li>`;
+        const opId = escapeHtml(extractOpId(ref.value));
+        refsInner += `<li><a href="#" class="ref-link" data-op-id="${opId}">${opId}</a></li>`;
       } else {
         refsInner += `<li><span class="ref-type">${escapeHtml(ref.type)}</span>: ${val}</li>`;
       }
@@ -751,8 +748,7 @@ async function loadFileContent(opId, filename, tabsDiv) {
     const ext = filename.split('.').pop().toLowerCase();
 
     if (ext === 'md' && typeof marked !== 'undefined') {
-      const rawHtml = marked.parse(text);
-      const sanitized = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(rawHtml) : rawHtml;
+      const sanitized = renderMarkdown(text);
       contentArea.innerHTML = `<div class="md-content">${sanitized}</div>`;
     } else if (ext === 'html' || ext === 'htm') {
       const fileUrl = `/api/file?op=${encodeURIComponent(opId)}&file=${encodeURIComponent(filename)}`;
@@ -775,6 +771,23 @@ async function loadFileContent(opId, filename, tabsDiv) {
 
 function escapeHtml(str) {
   return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// Render markdown to sanitized HTML. Falls back to escaped plain text when
+// DOMPurify is unavailable so unsanitized marked output is never injected.
+function renderMarkdown(text) {
+  if (!text || typeof marked === 'undefined') return escapeHtml(text || '\u2014');
+  const raw = marked.parse(text);
+  if (typeof DOMPurify !== 'undefined') return DOMPurify.sanitize(raw);
+  return escapeHtml(text);
+}
+
+// Extract an operation ID (YYYYMMDD-hex) from a reference value that may be
+// a relative filesystem path like "../../squad/operations/20260317-b0320d3a/".
+function extractOpId(refValue) {
+  if (!refValue) return refValue;
+  const match = refValue.match(/(\d{8}-[0-9a-f]+)/);
+  return match ? match[1] : refValue;
 }
 
 // Resize iframe to its content height so it scrolls with the parent

--- a/static/app.js
+++ b/static/app.js
@@ -524,37 +524,48 @@ async function selectOp(op) {
   showTab('detail');
 
   // Tear down any prior iframe's resize listeners before rebuilding
-  // #file-content-area; covers branches (e.g. zero-files op) that don't
-  // delegate to loadFileContent.
   teardownActiveIframeResize();
 
   document.getElementById('detail-empty').style.display = 'none';
   const content = document.getElementById('detail-content');
   content.style.display = '';
 
-  // Build metadata section
+  // #6 Status surface: bucket-colored left-border on detail panel
+  content.className = '';
+  const border = cardBorderClass(op);
+  if (border) content.classList.add('detail-panel', border);
+
   const dotClass = statusDotClass(op);
   const createdRel = relativeTime(op.created_at);
   const completedRel = op.completed_at ? relativeTime(op.completed_at) : 'running';
-  let html = `
-    <div class="detail-field">
-      <div class="detail-label">Operation</div>
-      <div class="detail-value">${escapeHtml(op.id)} &nbsp; <span class="status-dot ${dotClass}"></span>${escapeHtml(op.status)}</div>
-    </div>
-    <div class="detail-field">
-      <div class="detail-label">Squad</div>
-      <div class="detail-value"><span class="squad-chip" style="background:${squadColor(op.squad || '')}">${escapeHtml(op.squad)}</span></div>
-    </div>
+
+  // #1 Markdown render brief/summary
+  const briefHtml = (op.brief && typeof marked !== 'undefined')
+    ? (typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(marked.parse(op.brief)) : marked.parse(op.brief))
+    : escapeHtml(op.brief || '\u2014');
+  const summaryHtml = (op.summary && typeof marked !== 'undefined')
+    ? (typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(marked.parse(op.summary)) : marked.parse(op.summary))
+    : '';
+
+  // #2 Sidebar metadata layout (right sidebar) + main column
+  let html = '<div class="detail-layout">';
+
+  // Main column (left)
+  html += '<div class="detail-main">';
+  html += `
     <div class="detail-field">
       <div class="detail-label">Brief</div>
-      <div class="detail-value">${escapeHtml(op.brief || '\u2014')}</div>
-    </div>
-    ${op.summary ? `<div class="detail-field"><div class="detail-label">Summary</div><div class="detail-value">${escapeHtml(op.summary)}</div></div>` : ''}
-    <div class="detail-field">
-      <div class="detail-label">Duration</div>
-      <div class="detail-value">${escapeHtml(op.elapsed || '\u2014')} &nbsp; (<span title="${escapeHtml(op.created_at || '')}">${escapeHtml(createdRel || '?')}</span> \u2192 <span title="${escapeHtml(op.completed_at || '')}">${escapeHtml(completedRel)}</span>)</div>
+      <div class="detail-value"><div class="md-content">${briefHtml}</div></div>
     </div>
   `;
+  if (op.summary) {
+    html += `
+    <div class="detail-field">
+      <div class="detail-label">Summary</div>
+      <div class="detail-value"><div class="md-content">${summaryHtml}</div></div>
+    </div>
+    `;
+  }
 
   // Failure block: structured display when op has a failure_reason
   if (op.status === 'failed' && op.failure_reason && typeof FAILURE_REASONS !== 'undefined') {
@@ -591,6 +602,59 @@ async function selectOp(op) {
     `;
   }
 
+  // #3 References folding
+  if (op.references && op.references.length > 0) {
+    let refsInner = '';
+    op.references.forEach(ref => {
+      const val = escapeHtml(ref.value);
+      if (ref.type === 'operation') {
+        refsInner += `<li><a href="#" class="ref-link" data-op-id="${val}">${val}</a></li>`;
+      } else {
+        refsInner += `<li><span class="ref-type">${escapeHtml(ref.type)}</span>: ${val}</li>`;
+      }
+    });
+    html += `
+    <details class="detail-references">
+      <summary>References (${op.references.length})</summary>
+      <ul>${refsInner}</ul>
+    </details>
+    `;
+  }
+
+  html += '</div>'; // end detail-main
+
+  // Sidebar (right)
+  html += '<div class="detail-sidebar">';
+  html += `
+    <div class="sidebar-field">
+      <div class="sidebar-label">Operation</div>
+      <div class="sidebar-value mono">${escapeHtml(op.id)}</div>
+    </div>
+    <div class="sidebar-field">
+      <div class="sidebar-label">Squad</div>
+      <div class="sidebar-value"><span class="squad-chip" style="background:${squadColor(op.squad || '')}">${escapeHtml(op.squad || '\u2014')}</span></div>
+    </div>
+    <div class="sidebar-field">
+      <div class="sidebar-label">Status</div>
+      <div class="sidebar-value"><span class="status-dot ${dotClass}"></span>${escapeHtml(op.status)}</div>
+    </div>
+    <div class="sidebar-field">
+      <div class="sidebar-label">Duration</div>
+      <div class="sidebar-value">${escapeHtml(op.elapsed || '\u2014')}</div>
+    </div>
+    <div class="sidebar-field">
+      <div class="sidebar-label">Created</div>
+      <div class="sidebar-value" title="${escapeHtml(op.created_at || '')}">${escapeHtml(createdRel || '?')}</div>
+    </div>
+    <div class="sidebar-field">
+      <div class="sidebar-label">Completed</div>
+      <div class="sidebar-value" title="${escapeHtml(op.completed_at || '')}">${escapeHtml(completedRel)}</div>
+    </div>
+  `;
+  html += '</div>'; // end detail-sidebar
+  html += '</div>'; // end detail-layout
+
+  // File tabs and content (full width, outside the 2-column grid)
   html += `
     <div id="file-tabs-container"></div>
     <div class="detail-field">
@@ -600,12 +664,36 @@ async function selectOp(op) {
   `;
   content.innerHTML = html;
 
+  // Bind reference link click handlers (event delegation)
+  content.querySelectorAll('.ref-link').forEach(link => {
+    link.addEventListener('click', async (e) => {
+      e.preventDefault();
+      const refId = link.dataset.opId;
+      try {
+        const resp = await fetch('/api/ops?q=' + encodeURIComponent(refId) + '&limit=100');
+        const data = await resp.json();
+        const refOp = (data.operations || []).find(o => o.id === refId);
+        if (refOp) selectOp(refOp);
+        else toast('Referenced operation not found: ' + refId);
+      } catch (err) {
+        toast('Failed to load reference: ' + err.message, 'error');
+      }
+    });
+  });
+
+  // Stale-request guard
+  if (selectedOp !== op.id) return;
+
   // Fetch file list
   let files = [];
   try {
     const filesResp = await fetch(`/api/files?op=${encodeURIComponent(op.id)}`);
+    if (selectedOp !== op.id) return;
     if (filesResp.ok) files = (await filesResp.json()) || [];
   } catch(e) {}
+
+  // Stale-request guard after files fetch
+  if (selectedOp !== op.id) return;
 
   // Render file tabs
   const tabsContainer = document.getElementById('file-tabs-container');
@@ -621,8 +709,6 @@ async function selectOp(op) {
       tabsDiv.appendChild(tab);
     });
     tabsContainer.appendChild(tabsDiv);
-    // File tabs already display the active filename; suppress the redundant
-    // heading above the content area to avoid duplication.
     if (labelEl) labelEl.style.display = 'none';
   }
 
@@ -632,7 +718,7 @@ async function selectOp(op) {
     loadFileContent(op.id, defaultFile, tabsContainer.querySelector('.file-tabs'));
   } else {
     document.getElementById('file-content-label').textContent = '';
-    document.getElementById('file-content-pre').textContent = 'No files available';
+    document.getElementById('file-content-area').textContent = 'No files available';
   }
 
   // Highlight selected card

--- a/static/index.html
+++ b/static/index.html
@@ -49,8 +49,8 @@
 
   <div class="right">
     <div class="right-header">
-      <div class="tab active" id="tab-session" onclick="showTab('session')">Session</div>
-      <div class="tab" id="tab-detail" onclick="showTab('detail')">Detail</div>
+      <div class="tab tab-primary active" id="tab-session" onclick="showTab('session')">Session</div>
+      <div class="tab tab-primary" id="tab-detail" onclick="showTab('detail')">Detail</div>
       <div id="runtime-tabs" style="margin-left:auto;display:flex;gap:4px;"></div>
     </div>
     <div class="right-content">

--- a/static/style.css
+++ b/static/style.css
@@ -80,8 +80,11 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
 /* Right panel */
 .right { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 .right-header { display: flex; align-items: center; padding: 8px 16px; background: var(--color-canvas-overlay); border-bottom: 1px solid var(--color-border-default); gap: 8px; }
+/* #4 Tab hierarchy: top-level tabs (Session/Detail) get heavier visual weight */
 .tab { padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px; color: var(--color-fg-muted); }
 .tab.active { background: var(--color-canvas-subtle); color: var(--color-fg-default); }
+.tab-primary { padding: 8px 18px; font-size: 14px; font-weight: 600; border: 1px solid var(--color-border-default); }
+.tab-primary.active { background: var(--color-accent-fg); color: #fff; border-color: var(--color-accent-fg); }
 .right-content { flex: 1; overflow: hidden; position: relative; }
 
 /* Terminal */
@@ -136,6 +139,38 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; b
    scroll handles long content instead of producing a nested scrollbar. */
 .html-frame { width: 100%; border: 1px solid var(--color-border-default); border-radius: 8px; background: #fff; display: block; }
 .open-tab-btn { display: inline-block; margin-bottom: 8px; padding: 4px 12px; background: var(--color-canvas-subtle); border: 1px solid var(--color-border-default); color: var(--color-accent-fg); border-radius: 6px; cursor: pointer; font-size: 12px; text-decoration: none; }
+
+/* #2 Detail layout: two-column grid (main + sidebar) */
+.detail-layout { display: grid; grid-template-columns: minmax(0, 1fr) 200px; gap: 24px; margin-bottom: 16px; }
+.detail-main { min-width: 0; }
+.detail-sidebar { display: flex; flex-direction: column; gap: 12px; padding: 12px; background: var(--color-canvas-overlay); border: 1px solid var(--color-border-default); border-radius: 8px; align-self: start; }
+.sidebar-field {}
+.sidebar-label { font-size: 10px; text-transform: uppercase; color: var(--color-fg-muted); letter-spacing: 0.5px; margin-bottom: 2px; }
+.sidebar-value { font-size: 13px; color: var(--color-fg-default); line-height: 1.4; overflow-wrap: anywhere; }
+.sidebar-value.mono { font-family: var(--font-mono); font-size: 12px; }
+@media (max-width: 700px) {
+  .detail-layout { grid-template-columns: 1fr; }
+  .detail-sidebar { order: -1; }
+}
+
+/* #3 References folding */
+.detail-references { margin-top: 8px; margin-bottom: 16px; }
+.detail-references summary { cursor: pointer; font-size: 13px; color: var(--color-fg-muted); padding: 6px 0; font-weight: 500; }
+.detail-references summary:hover { color: var(--color-fg-default); }
+.detail-references ul { list-style: none; padding: 4px 0 4px 8px; }
+.detail-references li { padding: 4px 0; font-size: 13px; font-family: var(--font-mono); }
+.detail-references .ref-link { color: var(--color-accent-fg); text-decoration: none; }
+.detail-references .ref-link:hover { text-decoration: underline; }
+.detail-references .ref-type { color: var(--color-fg-muted); font-size: 11px; text-transform: uppercase; }
+
+/* #6 Status surface: bucket-colored left-border on detail panel */
+.detail-panel { border-left: 4px solid transparent; padding-left: 16px; }
+.detail-panel.border-cancelled { border-left-color: var(--color-fg-muted); }
+.detail-panel.border-crashed { border-left-color: var(--color-danger-fg); }
+.detail-panel.border-setup { border-left-color: var(--color-attention-fg); }
+.detail-panel.border-config { border-left-color: var(--color-done-fg); }
+.detail-panel.border-active { border-left-color: var(--color-success-fg); }
+.detail-panel.border-completed { border-left-color: var(--color-fg-muted); }
 
 /* Empty state */
 .empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--color-fg-muted); font-size: 14px; }


### PR DESCRIPTION
## What
Implements six detail page improvements for the operation detail view as specified in issue #27.

## Why
The detail view needed better information hierarchy, markdown rendering for briefs/summaries, and consistent time display to match the card UX improvements from PR #33.

## Changes
- **main.go**: Added `RefView` type and `References` field to `OpView`; populated from `operation.Operation.References` in `opToView()`
- **static/app.js**: Rewrote `selectOp()` with:
  1. Markdown rendering for brief/summary via `marked.parse()` + `DOMPurify.sanitize()`
  2. Two-column CSS grid layout (main content + right sidebar with metadata)
  3. Collapsible `<details>` element for references with clickable operation links
  4. Stale-request guards after async fetches to prevent race conditions
- **static/style.css**: Added styles for detail layout grid, sidebar metadata, references folding, tab hierarchy (`.tab-primary`), and bucket-colored left-border on detail panel
- **static/index.html**: Added `tab-primary` class to Session/Detail tabs for visual hierarchy

## How to Test
1. `go build ./...` — compilation passes
2. `go test ./...` — all tests pass
3. Open dashboard, select an operation → verify:
   - Brief/summary render as markdown
   - Metadata appears in right sidebar
   - References section folds/unfolds (for ops with references)
   - Session/Detail tabs have heavier visual weight than file tabs
   - Created/completed show relative time with ISO tooltip on hover
   - Detail panel has colored left border matching op status

Closes #27