### PR TITLE
fix: remove Active/Queued options from status filter dropdown

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -347,11 +347,9 @@ function parseFilterValue(dropdown) {
 // Compute the status filter for the history list.
 // - No dropdown filter → all terminal statuses
 // - Dropdown matches a terminal status → that single status
-// - Dropdown matches an active-bucket status → treat as no filter (show all terminal)
 function historyStatusFilter(dropdown) {
   const { status } = parseFilterValue(dropdown);
   if (!status) return HISTORY_STATUSES;
-  if (status === 'active' || status === 'queued') return HISTORY_STATUSES;
   return status;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -30,8 +30,6 @@
       <select id="filter-squad"><option value="">All Squads</option></select>
       <select id="filter-status">
         <option value="">All Status</option>
-        <option value="active">Active</option>
-        <option value="queued">Queued</option>
         <option value="completed">Completed</option>
         <option value="failed">Failed</option>
         <option value="failed:crashed">&nbsp;&nbsp;↳ Crashed</option>


### PR DESCRIPTION
## What
Remove the "Active" and "Queued" options from the history status filter dropdown and clean up the dead code branch in `historyStatusFilter()`.

## Why
PR #37 decoupled the Active section from the status dropdown — active/queued ops are always shown in the dedicated Active section above. The dropdown options for these statuses now do nothing useful and are confusing.

## Changes
- `static/index.html`: Remove `<option value="active">Active</option>` and `<option value="queued">Queued</option>` from the filter dropdown
- `static/app.js`: Remove the dead `if (status === 'active' || status === 'queued')` branch and its associated comment in `historyStatusFilter()`

## How to Test
1. Open the dashboard
2. Verify the status dropdown contains: All Status, Completed, Failed, and failure sub-buckets (Crashed, Setup Failed, Config Needed, Cancelled)
3. Verify "Active" and "Queued" are no longer in the dropdown
4. Verify filtering by Completed/Failed/sub-buckets still works
5. Verify the Active section still shows active/queued ops independently