### PR TITLE
fix: synchronize Active, History, and Stats refresh intervals

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -707,6 +707,54 @@ async function loadHistoryOps(reset = true) {
   }
 }
 
+// Auto-refresh variant: fetches the first page and merges into the
+// existing cache so newly completed operations appear without resetting
+// scroll position or pagination state.
+async function refreshHistoryOps() {
+  if (isLoadingHistory) return;
+
+  const squad = document.getElementById('filter-squad').value;
+  const keyword = document.getElementById('filter-keyword').value;
+  const dropdown = document.getElementById('filter-status').value;
+  const filter = historyStatusFilter(dropdown);
+  if (filter === null) return;
+
+  const params = new URLSearchParams({ limit: '20', offset: '0', status: filter });
+  if (squad) params.set('squad', squad);
+  if (keyword) params.set('q', keyword);
+
+  try {
+    const resp = await fetch(`/api/ops?${params}`);
+    const data = await resp.json();
+    const rawOps = data.operations || [];
+    historyTotal = data.total || 0;
+
+    const ops = applyBucketFilter(rawOps, dropdown);
+    lastHistoryCount = historyTotal;
+    updateSectionCounts();
+
+    // Merge: update existing items in-place, prepend genuinely new ones
+    const existingIds = new Set(historyOpsCache.map(o => o.id));
+    let insertedCount = 0;
+    for (const op of ops) {
+      if (!existingIds.has(op.id)) {
+        historyOpsCache.unshift(op);
+        existingIds.add(op.id);
+        insertedCount++;
+      } else {
+        const idx = historyOpsCache.findIndex(o => o.id === op.id);
+        if (idx !== -1) historyOpsCache[idx] = op;
+      }
+    }
+
+    // Keep pagination offset aligned so "Load more" fetches the right slice
+    historyOffset += insertedCount;
+
+    renderHistoryWithBuckets();
+    updateInfiniteScroll();
+  } catch(e) { /* silent on auto-refresh */ }
+}
+
 async function loadMore() {
   if (isLoadingHistory) return;
   isLoadingHistory = true;
@@ -1531,12 +1579,12 @@ loadStats();
 initTerminal();
 loadRuntimes();
 
-// Independent refresh policies:
-//   - active list polls frequently (live data)
-//   - history list never auto-polls; user pulls via filter change or "Load more"
-//   - stats refresh on a slower cadence
-setInterval(loadActiveOps, 5000);
-setInterval(loadStats, 10000);
+// Synchronized refresh: all lists update together so operations
+// transitioning from active → history don't appear to vanish.
+const REFRESH_INTERVAL = 5000;
+setInterval(loadActiveOps, REFRESH_INTERVAL);
+setInterval(refreshHistoryOps, REFRESH_INTERVAL);
+setInterval(loadStats, REFRESH_INTERVAL);
 
 async function loadRuntimes(skipAutoConnect) {
   try {

--- a/static/app.js
+++ b/static/app.js
@@ -719,6 +719,8 @@ async function refreshHistoryOps() {
   const filter = historyStatusFilter(dropdown);
   if (filter === null) return;
 
+  isLoadingHistory = true;
+
   const params = new URLSearchParams({ limit: '20', offset: '0', status: filter });
   if (squad) params.set('squad', squad);
   if (keyword) params.set('q', keyword);
@@ -735,24 +737,25 @@ async function refreshHistoryOps() {
 
     // Merge: update existing items in-place, prepend genuinely new ones
     const existingIds = new Set(historyOpsCache.map(o => o.id));
-    let insertedCount = 0;
+    const newItems = [];
     for (const op of ops) {
       if (!existingIds.has(op.id)) {
-        historyOpsCache.unshift(op);
+        newItems.push(op);
         existingIds.add(op.id);
-        insertedCount++;
       } else {
         const idx = historyOpsCache.findIndex(o => o.id === op.id);
         if (idx !== -1) historyOpsCache[idx] = op;
       }
     }
+    if (newItems.length) historyOpsCache.unshift(...newItems);
 
     // Keep pagination offset aligned so "Load more" fetches the right slice
-    historyOffset += insertedCount;
+    historyOffset += newItems.length;
 
     renderHistoryWithBuckets();
     updateInfiniteScroll();
   } catch(e) { /* silent on auto-refresh */ }
+  finally { isLoadingHistory = false; }
 }
 
 async function loadMore() {


### PR DESCRIPTION
## What
Synchronize the dashboard refresh intervals so Active, History, and Stats all update on the same 5-second cadence.

## Why
When an operation completes, it disappears from the Active list (which polls every 5s) but does NOT appear in the History list because History never auto-refreshes. This makes completed operations appear to vanish. Stats also refreshes on a different cadence (10s), causing inconsistent counts.

## Changes
- **static/app.js**: Added \\efreshHistoryOps()\\ function that fetches the first page of history results and merges them into the existing cache without resetting scroll position or pagination state
- **static/app.js**: Updated setInterval block to use a shared \\REFRESH_INTERVAL = 5000\\ constant for all three refresh calls (Active, History, Stats)
- Existing items are updated in-place; genuinely new items are prepended
- \\historyOffset\\ is adjusted by the count of inserted items so Load More pagination stays aligned
- Guarded with \\isLoadingHistory\\ to prevent race conditions with concurrent user actions

## How to Test
1. Dispatch an operation and wait for it to complete
2. Verify: it disappears from Active and appears in History within the same ~5s refresh cycle
3. Load more history pages, then wait for a new operation to complete — verify scroll position and pagination are preserved
4. Verify Stats counts stay consistent with Active + History totals