### PR TITLE
fix: opDir() falls back to _unclassified for classifying operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -567,13 +567,34 @@ func handleSquads(w http.ResponseWriter, r *http.Request) {
 }
 
 // opDir returns the filesystem path for a given operation ID.
+// It checks the assigned squad directory first, then falls back to _unclassified
+// (where operations reside during the classify phase).
 func opDir(opID string) (string, error) {
 	op, err := operation.Find(opID)
 	if err != nil {
 		return "", err
 	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".swat", "squads", op.Squad, "operations", opID), nil
+
+	// Primary path: the assigned squad's operation directory
+	if op.Squad != "" {
+		primary := filepath.Join(home, ".swat", "squads", op.Squad, "operations", opID)
+		if _, err := os.Stat(primary); err == nil {
+			return primary, nil
+		}
+	}
+
+	// Fallback: operation may still be in _unclassified during classify phase
+	fallback := filepath.Join(home, ".swat", "squads", "_unclassified", "operations", opID)
+	if _, err := os.Stat(fallback); err == nil {
+		return fallback, nil
+	}
+
+	// Neither exists — return the primary path (will trigger 404 downstream)
+	if op.Squad != "" {
+		return filepath.Join(home, ".swat", "squads", op.Squad, "operations", opID), nil
+	}
+	return fallback, nil
 }
 
 // handleOpFiles returns a JSON array of relative file paths in the operation directory,


### PR DESCRIPTION
## What
Fix `opDir()` to fall back to `_unclassified` directory when the primary squad path doesn't exist on disk.

## Why
When an operation is in `classifying` state, it physically lives in `~/.swat/squads/_unclassified/operations/<id>/`. However, `opDir()` resolves the path using `op.Squad` which may be empty or already set to the target squad before the directory is moved. This causes the dashboard to show "Failed to load OPERATION.md" for classifying operations.

## Changes
- `main.go`: Rewrote `opDir()` to check if the primary squad directory exists (`os.Stat`), then fall back to `_unclassified`. If neither exists, returns the primary path for a proper 404 downstream.

## How to Test
1. Start an operation that triggers classification (e.g., dispatch a task)
2. While it's in `classifying` state, click it in the dashboard
3. Verify OPERATION.md content loads correctly
4. Verify operations in `active`/`completed` state still resolve to their correct squad directory